### PR TITLE
fix: overhaul promptWalletConnection, handleSearch, selectSearchSuggestion in Help.jsx

### DIFF
--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -582,6 +582,7 @@ export default function Help() {
   const [searchSuggestLoading, setSearchSuggestLoading] = useState(false)
   const [activeSuggestion, setActiveSuggestion] = useState(-1)
   const searchBoxRef = useRef(null)
+  const searchAbortRef = useRef(null)
 
   const [requestId, setRequestId] = useState(null)
   const [requestStatus, setRequestStatus] = useState('idle')
@@ -786,6 +787,11 @@ export default function Help() {
 
   async function promptWalletConnection() {
     try {
+      // Defer opening the modal to the next macrotask so the click handler
+      // that triggered this returns immediately instead of holding the main
+      // thread while the wallet-kit UI mounts (source of the inconsistent
+      // cross-browser behavior, worst on Safari/Firefox).
+      await new Promise((resolve) => setTimeout(resolve, 0))
       const { address } = await StellarWalletsKit.authModal()
       if (address) {
         setWalletAddress(address)
@@ -803,12 +809,19 @@ export default function Help() {
     e.preventDefault()
     const q = searchQuery.trim()
     if (!q) return
+    // Cancel any in-flight search before starting a new one, instead of
+    // letting overlapping requests race and both allocate/parse response
+    // bodies that only the latest result actually needs.
+    searchAbortRef.current?.abort()
+    const controller = new AbortController()
+    searchAbortRef.current = controller
     setSearchError('')
     setSearchSuggestions([])
     setSearchLoading(true)
     try {
       const res = await fetch(
-        `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?access_token=${MAPBOX_TOKEN}&limit=1`
+        `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?access_token=${MAPBOX_TOKEN}&limit=1`,
+        { signal: controller.signal }
       )
       const data = await res.json()
       if (!data.features?.length) { setSearchError('Place not found.'); setSearchLoading(false); return }
@@ -816,13 +829,17 @@ export default function Help() {
       setLocation([lat, lng])
       setLocationError('')
       setSearchSuggestions([])
-    } catch { setSearchError('Search failed. Check your connection.') }
+    } catch (err) {
+      if (err?.name !== 'AbortError') setSearchError('Search failed. Check your connection.')
+      else return
+    }
     setSearchLoading(false)
   }
 
   function selectSearchSuggestion(feature) {
-    if (!feature?.center) return
+    if (!Array.isArray(feature?.center) || feature.center.length !== 2) return
     const [lng, lat] = feature.center
+    if (!Number.isFinite(lng) || !Number.isFinite(lat)) return
     setLocation([lat, lng])
     setLocationError('')
     setSearchQuery(feature.place_name || feature.text || '')


### PR DESCRIPTION
Closes #271

---

Closes #273

---

Closes #270

---

Closes #274

---

## Summary
- Issue 270 / 271 — `promptWalletConnection` now yields to the event loop (`setTimeout(0)`) before opening the wallet-kit modal, so the click handler that triggers it returns immediately instead of blocking the main thread while the modal mounts.
- Issue 273 — `handleSearch` now cancels any in-flight geocode request via `AbortController` before starting a new one, avoiding redundant overlapping requests/allocations on rapid successive searches.
- Issue 274 — `selectSearchSuggestion` now validates `feature.center` is a proper `[lng, lat]` pair of finite numbers before using it, guarding against malformed suggestion data.

## Testing
- `npm run build` — passes