### PR TITLE
fix: harden next, ping, fetchRequester, and getRequest input validation

### DIFF
--- a/src/lib/contract.js
+++ b/src/lib/contract.js
@@ -181,8 +181,10 @@ async function resolveWalletAddress(wallet, fallback = '') {
 // ── Reads (no wallet needed) ───────────────────────────────────
 
 export async function getRequest(requestId) {
+  const id = safeToNumber(requestId)
+  if (!Number.isFinite(id) || id < 0) return null
   const sim = await simulateRead(
-    contract.call('get_request', scv(Number(requestId), { type: 'u64' }))
+    contract.call('get_request', scv(id, { type: 'u64' }))
   )
   if (!sim.result) return null
   const raw = scValToNative(sim.result.retval)

--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -1134,6 +1134,8 @@ const ET_ICONS = {
 
 /** Maximum number of log lines kept in the ring-buffer. */
 export const LOG_RING_SIZE = 6;
+/** Maximum character length of a single log message before truncation. */
+export const LOG_MAX_MSG_LENGTH = 200;
 
 /** Immutable initial state — also used as the reset target. */
 export const ZK_INITIAL = Object.freeze({
@@ -1190,7 +1192,12 @@ export function zkReducer(state, action) {
       return { ...state, proof: { ...state.proof, ...action.payload } };
 
     case "PUSH_LOG": {
-      const msg = action.payload;
+      const raw = String(action.payload ?? "");
+      // Truncate oversized messages to bound per-entry memory usage (#308)
+      const msg =
+        raw.length > LOG_MAX_MSG_LENGTH
+          ? raw.slice(0, LOG_MAX_MSG_LENGTH) + "…"
+          : raw;
       const prev = state.logs;
       // Consecutive-duplicate guard — identical adjacent messages are dropped
       if (prev.length > 0 && prev[prev.length - 1] === msg) return state;
@@ -2072,7 +2079,9 @@ export default function Help() {
     if (!lastOfferReceipt || responderArrived) return;
     let mounted = true;
     async function ping() {
+      if (!mounted) return;
       if (!validLocation()) return;
+      if (!activeWalletAddress || !lastOfferReceipt?.requestId) return;
       try {
         await updateLocation(
           activeWalletAddress,
@@ -2099,8 +2108,11 @@ export default function Help() {
     if (!lastOfferReceipt) return;
     let mounted = true;
     async function fetchRequester() {
+      if (!mounted) return;
+      const requestId = lastOfferReceipt?.requestId;
+      if (!requestId) return;
       try {
-        const req = await getRequest(lastOfferReceipt.requestId);
+        const req = await getRequest(requestId);
         if (mounted && req && req.lat != null && req.lng != null) {
           setRequesterLocation([req.lat, req.lng]);
         }


### PR DESCRIPTION
Closes #303
Closes #308
Closes #309
Closes #310

## Overview

Four related hardening changes across `Help.jsx` and `contract.js` addressing buffer safety, state-synchronization correctness, and input sanitization.

---

## #308 — Encapsulate `next` in the ZK log reducer (`Help.jsx`)

The `PUSH_LOG` reducer case wrote raw, unbounded string payloads into the ring-buffer. A WASM worker or network response could emit a very long string, causing each ring-buffer slot to hold an arbitrarily large value and inflating every downstream array spread (`[...prev, msg]`) to O(N) in message length.

**Fix:** Added `LOG_MAX_MSG_LENGTH = 200` and truncate any payload exceeding that limit before the duplicate-guard and ring-buffer append. The ring-buffer size cap (`LOG_RING_SIZE`) already bounded the *number* of entries; this change bounds the *size* of each entry, giving O(1) worst-case memory cost per `PUSH_LOG` dispatch.

```js
export const LOG_MAX_MSG_LENGTH = 200;

// inside PUSH_LOG case:
const msg = raw.length > LOG_MAX_MSG_LENGTH
  ? raw.slice(0, LOG_MAX_MSG_LENGTH) + "…"
  : raw;
```

---

## #309 — Enhance `ping` input validation (`Help.jsx`)

`ping` declared a `mounted` closure variable but never read it, leaving the interval free to call `updateLocation` with stale or empty state after the effect had cleaned up. Additionally `activeWalletAddress` and `lastOfferReceipt.requestId` were passed directly to the network call without presence checks, allowing empty-string or null values to propagate to the contract layer.

**Fix:** Added three guards at the top of `ping`:
1. `if (!mounted) return;` — stops network calls after the effect cleans up, preventing inaccurate state synchronization on unmounted effects.
2. `if (!activeWalletAddress || !lastOfferReceipt?.requestId) return;` — validates both required fields are present before dispatching the update.

---

## #310 — Sanitize `fetchRequester` (`Help.jsx`)

`fetchRequester` accessed `lastOfferReceipt.requestId` without a null-safe guard, and performed no `mounted` check at the start of the function body. If the interval fired immediately after the effect's cleanup, `setRequesterLocation` was protected but the `getRequest` RPC call still ran unnecessarily with a potentially stale or invalid ID.

**Fix:**
- Early `if (!mounted) return;` at function entry.
- Extract `requestId` via `lastOfferReceipt?.requestId` with an early return on falsy value, so the RPC call is never dispatched with an invalid ID.

---

## #303 — Encapsulate `result` / validate input in `getRequest` (`contract.js`)

`getRequest` passed `Number(requestId)` directly to the RPC contract call with no validation. A `null`, `undefined`, or non-numeric `requestId` would produce `NaN`, which the `scv` encoder would serialize as `0` — silently querying the wrong contract slot (request #0) rather than returning early. This created an implicit O(N)-per-call semantic where callers could not distinguish "not found" from "wrong ID passed".

**Fix:** Validate via the existing `safeToNumber` helper and guard `id >= 0 && isFinite(id)` before constructing the RPC call. Invalid IDs now return `null` immediately, consistent with the "not found" contract.

```js
const id = safeToNumber(requestId)
if (!Number.isFinite(id) || id < 0) return null
```

## Files changed

| File | Change |
|------|--------|
| `src/pages/Help.jsx` | `LOG_MAX_MSG_LENGTH` constant + truncation in `PUSH_LOG`; `mounted` + presence guards in `ping`; `mounted` + `requestId` guard in `fetchRequester` |
| `src/lib/contract.js` | `safeToNumber` validation + non-negative guard in `getRequest` |