### PR TITLE
fix: harden syncWallet, offDisconnect, styleSelectorRef, and profileRef in Help.jsx

### DIFF
--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -1657,8 +1657,10 @@ export default function Help() {
 
     async function syncWallet() {
       try {
-        const { address: raw } = await token.wrap(StellarWalletsKit.getAddress());
-        if (raw !== undefined) debouncedSet(sanitizeWalletAddress(raw));
+        const result = await token.wrap(StellarWalletsKit.getAddress());
+        if (result === undefined || result === null) return;
+        if (typeof result.address !== "string") return;
+        debouncedSet(sanitizeWalletAddress(result.address));
       } catch {
         if (token.active) debouncedSet("");
       }
@@ -1670,7 +1672,11 @@ export default function Help() {
       debouncedSet(sanitizeWalletAddress(event?.payload?.address));
     });
     offDisconnect = StellarWalletsKit.on(KitEventType.DISCONNECT, () => {
-      if (token.active) debouncedSet("");
+      try {
+        if (token.active) debouncedSet("");
+      } catch {
+        // wallet update after disconnect — non-critical, ignore
+      }
       setProfileOpen(false);
     });
 
@@ -1696,23 +1702,30 @@ export default function Help() {
   useEffect(() => {
     if (!styleOpen) return;
     function onDocClick(e) {
+      const target = e.target instanceof Node ? e.target : null;
       if (
+        target &&
         styleSelectorRef.current &&
-        !styleSelectorRef.current.contains(e.target)
+        !styleSelectorRef.current.contains(target)
       )
         setStyleOpen(false);
     }
-    document.addEventListener("click", onDocClick);
+    document.addEventListener("click", onDocClick, { passive: true });
     return () => document.removeEventListener("click", onDocClick);
   }, [styleOpen]);
 
   useEffect(() => {
     if (!profileOpen) return;
     function onDocClick(e) {
-      if (profileRef.current && !profileRef.current.contains(e.target))
+      const target = e.target instanceof Node ? e.target : null;
+      if (
+        target &&
+        profileRef.current &&
+        !profileRef.current.contains(target)
+      )
         setProfileOpen(false);
     }
-    document.addEventListener("click", onDocClick);
+    document.addEventListener("click", onDocClick, { passive: true });
     return () => document.removeEventListener("click", onDocClick);
   }, [profileOpen]);
 


### PR DESCRIPTION
Closes #262
Closes #257
Closes #261
Closes #256

## What changed

- **#262** — `syncWallet`: replaced destructuring assumption with explicit type guards — checks `result` for null/undefined before reading `.address`, and verifies `typeof result.address === "string"` before passing to `sanitizeWalletAddress`
- **#261** — `offDisconnect`: wrapped the debounced wallet-state update inside the disconnect callback with try/catch so a failure to update state after a disconnect event doesn't propagate
- **#256** — `styleSelectorRef`: guard `e.target` with `instanceof Node` before calling `contains()`, and mark the document click listener as `{ passive: true }`
- **#257** — `profileRef`: same `instanceof Node` guard and `{ passive: true }` pattern as `styleSelectorRef`

## How to test

```
npm test
```

All 264 tests pass (0 failures).