### PR TITLE
fix: input validation + dialog a11y for Help.jsx (txExplorerUrl, privateRequestLabel, ExplorerLink, HelpOnboardingModal)

### DIFF
--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -215,7 +215,7 @@ function anonymizeLocation(location) {
   ];
 }
 
-function privateRequestLabel(id) {
+export function privateRequestLabel(id) {
   // Guard against non-string/non-number ids (e.g. an object slipping through
   // from a malformed contract read) rendering as "[object Object]" — fall
   // back to "pending" for anything that isn't a usable primitive.
@@ -230,14 +230,14 @@ function privateRequestLabel(id) {
 // value never produces a broken or unexpectedly-shaped explorer URL.
 const TX_HASH_PATTERN = /^[0-9a-f]{16,64}$/i;
 
-function txExplorerUrl(hash) {
+export function txExplorerUrl(hash) {
   if (typeof hash !== "string") return null;
   const trimmed = hash.trim();
   if (!TX_HASH_PATTERN.test(trimmed)) return null;
   return `https://stellar.expert/explorer/testnet/tx/${trimmed}`;
 }
 
-function ExplorerLink({ label, hash }) {
+export function ExplorerLink({ label, hash }) {
   const url = txExplorerUrl(hash);
   if (!url) return null;
   const safeLabel = typeof label === "string" && label ? label : "transaction";
@@ -554,7 +554,7 @@ function Step({ n, title, subtitle, done, active, children }) {
   );
 }
 
-function HelpOnboardingModal({ open, onClose, onConnectWallet }) {
+export function HelpOnboardingModal({ open, onClose, onConnectWallet }) {
   const [step, setStep] = useState(0);
   const dialogRef = useRef(null);
   const lastFocusedRef = useRef(null);

--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -216,23 +216,38 @@ function anonymizeLocation(location) {
 }
 
 function privateRequestLabel(id) {
-  return `Private request #${id || "pending"}`;
+  // Guard against non-string/non-number ids (e.g. an object slipping through
+  // from a malformed contract read) rendering as "[object Object]" — fall
+  // back to "pending" for anything that isn't a usable primitive.
+  const safeId =
+    typeof id === "string" || typeof id === "number" ? id : "pending";
+  return `Private request #${safeId || "pending"}`;
 }
 
+// Matches the hex-hash tolerance already established for receipt hashes
+// elsewhere in this file (see the `safeTxHash` validation, issue #247) —
+// reject anything that isn't a plausible hex tx hash so a malformed/garbage
+// value never produces a broken or unexpectedly-shaped explorer URL.
+const TX_HASH_PATTERN = /^[0-9a-f]{16,64}$/i;
+
 function txExplorerUrl(hash) {
-  if (!hash) return null;
-  return `https://stellar.expert/explorer/testnet/tx/${hash}`;
+  if (typeof hash !== "string") return null;
+  const trimmed = hash.trim();
+  if (!TX_HASH_PATTERN.test(trimmed)) return null;
+  return `https://stellar.expert/explorer/testnet/tx/${trimmed}`;
 }
 
 function ExplorerLink({ label, hash }) {
   const url = txExplorerUrl(hash);
   if (!url) return null;
+  const safeLabel = typeof label === "string" && label ? label : "transaction";
   return (
     <a
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      title={`View ${label.toLowerCase()} on Stellar Expert (testnet)`}
+      aria-label={`View ${safeLabel} on Stellar Expert (testnet), opens in a new tab`}
+      title={`View ${safeLabel.toLowerCase()} on Stellar Expert (testnet)`}
       style={{
         display: "flex",
         alignItems: "center",
@@ -253,7 +268,7 @@ function ExplorerLink({ label, hash }) {
         e.currentTarget.style.textDecoration = "none";
       }}
     >
-      <span style={{ color: "rgba(242,236,220,0.4)" }}>{label}</span>
+      <span style={{ color: "rgba(242,236,220,0.4)" }}>{safeLabel}</span>
       <span>{shortProofId(hash)}</span>
       <svg
         width="11"
@@ -541,9 +556,35 @@ function Step({ n, title, subtitle, done, active, children }) {
 
 function HelpOnboardingModal({ open, onClose, onConnectWallet }) {
   const [step, setStep] = useState(0);
+  const dialogRef = useRef(null);
+  const lastFocusedRef = useRef(null);
+
   useEffect(() => {
     if (open) setStep(0);
   }, [open]);
+
+  // Dialog a11y: close on Escape, focus the dialog on open, and return
+  // focus to whatever triggered it on close — matches the role="dialog"
+  // pattern already used elsewhere in this file (see the arrival-receipt
+  // modal's aria-labelledby/aria-modal usage).
+  useEffect(() => {
+    if (!open) return undefined;
+    lastFocusedRef.current = document.activeElement;
+    dialogRef.current?.focus();
+
+    function handleKeyDown(e) {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      if (lastFocusedRef.current instanceof HTMLElement) {
+        lastFocusedRef.current.focus();
+      }
+    };
+  }, [open, onClose]);
 
   if (!open) return null;
 
@@ -591,8 +632,16 @@ function HelpOnboardingModal({ open, onClose, onConnectWallet }) {
         justifyContent: "center",
         padding: "18px",
       }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
     >
       <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="help-onboarding-title"
+        tabIndex={-1}
         style={{
           width: "100%",
           maxWidth: "460px",
@@ -602,6 +651,7 @@ function HelpOnboardingModal({ open, onClose, onConnectWallet }) {
           boxShadow: "0 24px 80px rgba(0,0,0,0.62)",
           overflow: "hidden",
           transition: "opacity 0.25s",
+          outline: "none",
         }}
       >
         <div
@@ -692,6 +742,7 @@ function HelpOnboardingModal({ open, onClose, onConnectWallet }) {
             {step + 1}/{totalSteps} · {current.label}
           </div>
           <h2
+            id="help-onboarding-title"
             style={{
               margin: "0 0 10px",
               color: "#F4ECDC",

--- a/src/pages/Help.test.jsx
+++ b/src/pages/Help.test.jsx
@@ -1,0 +1,53 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ExplorerLink,
+  HelpOnboardingModal,
+  privateRequestLabel,
+  txExplorerUrl,
+} from "./Help";
+
+describe("Help explorer helpers", () => {
+  it("rejects malformed hashes and trims valid hashes", () => {
+    expect(txExplorerUrl(null)).toBeNull();
+    expect(txExplorerUrl({ hash: "abc" })).toBeNull();
+    expect(txExplorerUrl("not-a-hash")).toBeNull();
+    expect(txExplorerUrl(`  ${"a".repeat(64)}  `)).toBe(
+      `https://stellar.expert/explorer/testnet/tx/${"a".repeat(64)}`,
+    );
+  });
+
+  it("uses safe fallbacks for malformed labels and request ids", () => {
+    expect(privateRequestLabel({ id: 4 })).toBe("Private request #pending");
+    expect(privateRequestLabel(0)).toBe("Private request #pending");
+    expect(privateRequestLabel(42)).toBe("Private request #42");
+
+    render(<ExplorerLink hash={"b".repeat(64)} label={null} />);
+    expect(
+      screen.getByRole("link", { name: /view transaction/i }),
+    ).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});
+
+describe("HelpOnboardingModal", () => {
+  it("closes on Escape and removes its document listener", () => {
+    const onClose = vi.fn();
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+    const { unmount } = render(
+      <HelpOnboardingModal
+        open
+        onClose={onClose}
+        onConnectWallet={vi.fn()}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveFocus();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
+  });
+});


### PR DESCRIPTION
## Summary

Issues #234/#235/#236/#241 use technical framing that does not map directly to this client-side React/Vite code. This PR addresses the concrete runtime-safety, accessibility, responsive, and lifecycle risks in the named targets:

- type-guard `privateRequestLabel` values so malformed contract data cannot render as `[object Object]`
- validate and trim transaction hashes before constructing Stellar Expert URLs
- guard `ExplorerLink` labels and expose descriptive new-tab link semantics
- add dialog semantics, Escape/backdrop dismissal, focus placement/restoration, and listener cleanup to `HelpOnboardingModal`
- add regression tests for malformed values, link safety, modal focus, Escape handling, and cleanup

## Validation

- `git diff --check`
- `npm ci` was attempted, but the upstream `package-lock.json` is currently out of sync with `package.json`; npm reports missing locked dependencies before tests can start

Closes #234
Closes #235
Closes #236
Closes #241