### PR TITLE
Harden MY_REQUESTS_KEY storage helpers and anonymizeLocation in Help.jsx

### DIFF
--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -191,24 +191,42 @@ const DEFAULT_CENTER = [20, 0];
 
 const MY_REQUESTS_KEY = "hp_my_requests";
 
-function loadMyRequestIds() {
+// Some browsers (Safari private mode, storage disabled, strict privacy
+// settings) throw on localStorage access instead of just returning null,
+// and a stored value can be corrupted or hand-edited into a non-array.
+// Both paths must degrade to an empty list rather than crash the caller.
+export function loadMyRequestIds() {
   try {
-    return JSON.parse(localStorage.getItem(MY_REQUESTS_KEY) || "[]");
+    const parsed = JSON.parse(localStorage.getItem(MY_REQUESTS_KEY) || "[]");
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id) => Number.isFinite(id));
   } catch {
     return [];
   }
 }
 
-function saveMyRequestId(id) {
+export function saveMyRequestId(id) {
+  if (!Number.isFinite(id)) return;
   const ids = loadMyRequestIds();
   if (!ids.includes(id)) {
     ids.unshift(id);
-    localStorage.setItem(MY_REQUESTS_KEY, JSON.stringify(ids.slice(0, 20)));
+    try {
+      localStorage.setItem(MY_REQUESTS_KEY, JSON.stringify(ids.slice(0, 20)));
+    } catch {
+      // Storage quota exceeded or unavailable — the request itself was
+      // already created on-chain, so this must not fail the caller.
+    }
   }
 }
 
-function anonymizeLocation(location) {
-  if (!location) return location;
+export function anonymizeLocation(location) {
+  if (
+    !Array.isArray(location) ||
+    !Number.isFinite(location[0]) ||
+    !Number.isFinite(location[1])
+  ) {
+    throw new Error("Unable to read your location. Try again.");
+  }
   return [
     Math.round(location[0] * 100) / 100,
     Math.round(location[1] * 100) / 100,

--- a/test/my-requests-and-anonymize.test.js
+++ b/test/my-requests-and-anonymize.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  loadMyRequestIds,
+  saveMyRequestId,
+  anonymizeLocation,
+} from "../src/pages/Help.jsx";
+
+// ---------------------------------------------------------------------------
+// loadMyRequestIds / saveMyRequestId / anonymizeLocation
+//
+// loadMyRequestIds and saveMyRequestId share the "hp_my_requests" localStorage
+// key. Both must tolerate storage that throws (private browsing, quota,
+// disabled storage) or holds corrupted/tampered data without crashing the
+// caller. anonymizeLocation must reject malformed coordinates instead of
+// silently producing NaN that later fails deep inside the contract call.
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = "hp_my_requests";
+
+describe("loadMyRequestIds", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns an empty array when nothing is stored", () => {
+    expect(loadMyRequestIds()).toEqual([]);
+  });
+
+  it("returns previously stored ids", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([3, 2, 1]));
+    expect(loadMyRequestIds()).toEqual([3, 2, 1]);
+  });
+
+  it("returns an empty array on invalid JSON instead of throwing", () => {
+    localStorage.setItem(STORAGE_KEY, "{not json");
+    expect(loadMyRequestIds()).toEqual([]);
+  });
+
+  it("returns an empty array when the stored value is valid JSON but not an array", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ hijacked: true }));
+    expect(loadMyRequestIds()).toEqual([]);
+  });
+
+  it("returns an empty array when the stored value is JSON null", () => {
+    localStorage.setItem(STORAGE_KEY, "null");
+    expect(loadMyRequestIds()).toEqual([]);
+  });
+
+  it("drops non-finite entries from a tampered array", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([1, null, "abc", NaN, 2]),
+    );
+    expect(loadMyRequestIds()).toEqual([1, 2]);
+  });
+
+  it("returns an empty array when localStorage.getItem throws", () => {
+    const spy = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("SecurityError");
+      });
+    expect(loadMyRequestIds()).toEqual([]);
+    spy.mockRestore();
+  });
+});
+
+describe("saveMyRequestId", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("stores a new id", () => {
+    saveMyRequestId(42);
+    expect(loadMyRequestIds()).toEqual([42]);
+  });
+
+  it("prepends new ids so the most recent is first", () => {
+    saveMyRequestId(1);
+    saveMyRequestId(2);
+    expect(loadMyRequestIds()).toEqual([2, 1]);
+  });
+
+  it("does not duplicate an id that is already stored", () => {
+    saveMyRequestId(7);
+    saveMyRequestId(7);
+    expect(loadMyRequestIds()).toEqual([7]);
+  });
+
+  it("caps the stored list at 20 entries", () => {
+    for (let i = 1; i <= 25; i++) saveMyRequestId(i);
+    const ids = loadMyRequestIds();
+    expect(ids).toHaveLength(20);
+    expect(ids[0]).toBe(25);
+  });
+
+  it("ignores non-finite ids", () => {
+    saveMyRequestId(NaN);
+    saveMyRequestId(undefined);
+    expect(loadMyRequestIds()).toEqual([]);
+  });
+
+  it("does not throw when localStorage.setItem throws (quota exceeded / private mode)", () => {
+    const spy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+    expect(() => saveMyRequestId(9)).not.toThrow();
+    spy.mockRestore();
+  });
+});
+
+describe("anonymizeLocation", () => {
+  it("rounds coordinates to 2 decimal places (~1km precision)", () => {
+    expect(anonymizeLocation([40.712776, -74.005974])).toEqual([
+      40.71, -74.01,
+    ]);
+  });
+
+  it("throws when location is not an array", () => {
+    expect(() => anonymizeLocation(null)).toThrow();
+    expect(() => anonymizeLocation(undefined)).toThrow();
+  });
+
+  it("throws when a coordinate is missing or non-finite", () => {
+    expect(() => anonymizeLocation([40.71])).toThrow();
+    expect(() => anonymizeLocation([NaN, -74.01])).toThrow();
+    expect(() => anonymizeLocation([40.71, Infinity])).toThrow();
+  });
+});


### PR DESCRIPTION
  Summary

  Audited the four hp_my_requests localStorage helpers (MY_REQUESTS_KEY, loadMyRequestIds,
  saveMyRequestId) and anonymizeLocation in src/pages/Help.jsx, and fixed the real gaps found in
  each:

  - loadMyRequestIds — now validates the parsed value is actually an array and filters out
  non-finite entries before returning it. Previously, corrupted or hand-edited localStorage data
  (e.g. "null", an object, or stray NaN/null entries) would flow straight into ids.length /
  ids.map(...) in the "My Requests" polling effect and throw, silently breaking that poll on
  every browser where storage isn't in the expected shape.
  - saveMyRequestId — now guards against non-finite ids and wraps localStorage.setItem in a
  try/catch. Previously, a setItem failure (quota exceeded, Safari private browsing, disabled
  storage) would throw after the request had already been created on-chain, and that exception
  would bubble up into the surrounding handler's catch block and incorrectly show the user an
  error for a request that actually succeeded — an inconsistency that varies by browser/storage
  policy.
  - anonymizeLocation — now throws a clear, user-facing error ("Unable to read your location. Try
  again.") when given malformed input instead of silently returning undefined/NaN coordinates
  that would only fail later, deep inside the Soroban contract call, with an unhelpful error
  message.

  Testing

  - Added test/my-requests-and-anonymize.test.js — 16 unit tests covering:
  corrupted/non-array/JSON-null storage, non-finite id filtering, dedup, 20-entry cap,
  setItem/getItem throwing, and anonymizeLocation's input validation.
  - npx vitest run — 280/280 tests pass.
  - npm run build — production build succeeds.

  Closes #230
  Closes #231
  Closes #232
  Closes #233