### PR TITLE
Harden distance calc, RouteLine, loadProfile, and DEFAULT_CENTER in H…

### DIFF
--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -133,7 +133,17 @@ function MapController({ center, zoom = 14 }) {
   return null;
 }
 
-function distance(a, b) {
+export function distance(a, b) {
+  // Issue #226: guard against non-finite coords so a bad reading can't
+  // silently turn into NaN and get rendered as a distance.
+  if (
+    !Number.isFinite(a?.[0]) ||
+    !Number.isFinite(a?.[1]) ||
+    !Number.isFinite(b?.[0]) ||
+    !Number.isFinite(b?.[1])
+  ) {
+    return null;
+  }
   const R = 6371;
   const dLat = ((b[0] - a[0]) * Math.PI) / 180;
   const dLng = ((b[1] - a[1]) * Math.PI) / 180;
@@ -148,23 +158,29 @@ function distance(a, b) {
   return R * 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
 }
 
+// Issue #227: pure builder extracted so RouteLine can memoize on it instead
+// of allocating a fresh GeoJSON object identity on every render.
+export function buildRouteFeature(from, to) {
+  return {
+    type: "Feature",
+    geometry: {
+      type: "LineString",
+      coordinates: [
+        [from[1], from[0]],
+        [to[1], to[0]],
+      ],
+    },
+  };
+}
+
 function RouteLine({ id: routeId, from, to, color = "#7357FF" }) {
   const id = `route-${routeId || `${from[0]}-${from[1]}-${to[0]}-${to[1]}`}`;
+  const data = useMemo(
+    () => buildRouteFeature(from, to),
+    [from[0], from[1], to[0], to[1]],
+  );
   return (
-    <Source
-      id={id}
-      type="geojson"
-      data={{
-        type: "Feature",
-        geometry: {
-          type: "LineString",
-          coordinates: [
-            [from[1], from[0]],
-            [to[1], to[0]],
-          ],
-        },
-      }}
-    >
+    <Source id={id} type="geojson" data={data}>
       <Layer
         id={`${id}-line`}
         type="line"
@@ -179,15 +195,22 @@ function RouteLine({ id: routeId, from, to, color = "#7357FF" }) {
   );
 }
 
-function loadProfile() {
+export function loadProfile() {
   try {
-    return JSON.parse(localStorage.getItem("hp_profile") || "{}");
+    const parsed = JSON.parse(localStorage.getItem("hp_profile") || "{}");
+    // Issue #228: localStorage can hold valid-but-unexpected JSON (e.g. "null"
+    // or an array) — guard so callers always get a plain object back.
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : {};
   } catch {
     return {};
   }
 }
 
-const DEFAULT_CENTER = [20, 0];
+// Issue #229: frozen so this shared fallback map center can't be mutated
+// in place by a stray `.push`/index assignment elsewhere in the file.
+export const DEFAULT_CENTER = Object.freeze([20, 0]);
 
 const MY_REQUESTS_KEY = "hp_my_requests";
 
@@ -3073,19 +3096,24 @@ export default function Help() {
                             min
                           </>
                         )}
-                        {location && responders[0] && (
-                          <>
-                            {" "}
-                            ·{" "}
-                            {Math.round(
-                              distance(location, [
-                                responders[0].lat,
-                                responders[0].lng,
-                              ]) * 10,
-                            ) / 10}{" "}
-                            km away
-                          </>
-                        )}
+                        {location &&
+                          responders[0] &&
+                          distance(location, [
+                            responders[0].lat,
+                            responders[0].lng,
+                          ]) != null && (
+                            <>
+                              {" "}
+                              ·{" "}
+                              {Math.round(
+                                distance(location, [
+                                  responders[0].lat,
+                                  responders[0].lng,
+                                ]) * 10,
+                              ) / 10}{" "}
+                              km away
+                            </>
+                          )}
                       </div>
                     </div>
                   )}

--- a/test/default-center.test.js
+++ b/test/default-center.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_CENTER } from "../src/pages/Help.jsx";
+
+// ---------------------------------------------------------------------------
+// DEFAULT_CENTER tests
+//
+// Verifies the shared fallback map center is the expected [lat, lng] pair
+// and is frozen so it can't be mutated in place by a stray write elsewhere.
+// ---------------------------------------------------------------------------
+
+describe("DEFAULT_CENTER", () => {
+  it("is the expected [lat, lng] fallback", () => {
+    expect(DEFAULT_CENTER).toEqual([20, 0]);
+  });
+
+  it("is frozen and cannot be mutated", () => {
+    expect(Object.isFrozen(DEFAULT_CENTER)).toBe(true);
+    // ES modules run in strict mode, so writing to a frozen array throws.
+    expect(() => {
+      DEFAULT_CENTER[0] = 999;
+    }).toThrow();
+    expect(DEFAULT_CENTER).toEqual([20, 0]);
+  });
+});

--- a/test/distance.test.js
+++ b/test/distance.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { distance } from "../src/pages/Help.jsx";
+
+// ---------------------------------------------------------------------------
+// distance() tests
+//
+// Verifies the haversine helper (incl. the sinLng term) returns a correct
+// km distance for valid coordinates, and null — never NaN — for malformed
+// or missing coordinates, so callers can't silently render "NaN km away".
+// ---------------------------------------------------------------------------
+
+describe("distance — valid coordinates", () => {
+  it("returns 0 for identical points", () => {
+    expect(distance([10, 20], [10, 20])).toBe(0);
+  });
+
+  it("computes a known distance (roughly London to Paris, ~344km)", () => {
+    const london = [51.5074, -0.1278];
+    const paris = [48.8566, 2.3522];
+    const km = distance(london, paris);
+    expect(km).toBeGreaterThan(330);
+    expect(km).toBeLessThan(360);
+  });
+
+  it("is symmetric", () => {
+    const a = [10, 20];
+    const b = [30, 40];
+    expect(distance(a, b)).toBeCloseTo(distance(b, a), 10);
+  });
+});
+
+describe("distance — invalid coordinates", () => {
+  it("returns null when a coordinate is NaN", () => {
+    expect(distance([NaN, 20], [10, 20])).toBeNull();
+  });
+
+  it("returns null when a coordinate is undefined", () => {
+    expect(distance([undefined, 20], [10, 20])).toBeNull();
+  });
+
+  it("returns null when a coordinate is null", () => {
+    expect(distance([10, 20], [null, 20])).toBeNull();
+  });
+
+  it("returns null when a point is entirely missing", () => {
+    expect(distance(null, [10, 20])).toBeNull();
+    expect(distance([10, 20], undefined)).toBeNull();
+  });
+
+  it("returns null for Infinity", () => {
+    expect(distance([Infinity, 20], [10, 20])).toBeNull();
+  });
+});

--- a/test/load-profile.test.js
+++ b/test/load-profile.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { loadProfile } from "../src/pages/Help.jsx";
+
+// ---------------------------------------------------------------------------
+// loadProfile() tests
+//
+// Verifies the localStorage-backed profile loader always returns a plain
+// object, even when localStorage holds malformed or unexpected JSON, so
+// callers can safely read .nickname / .contact without crashing.
+// ---------------------------------------------------------------------------
+
+describe("loadProfile", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns an empty object when nothing is stored", () => {
+    expect(loadProfile()).toEqual({});
+  });
+
+  it("returns the stored profile object", () => {
+    localStorage.setItem(
+      "hp_profile",
+      JSON.stringify({ nickname: "Sam", contact: "sam@example.com" }),
+    );
+    expect(loadProfile()).toEqual({
+      nickname: "Sam",
+      contact: "sam@example.com",
+    });
+  });
+
+  it("returns an empty object for invalid JSON", () => {
+    localStorage.setItem("hp_profile", "{not json");
+    expect(loadProfile()).toEqual({});
+  });
+
+  it("returns an empty object when the stored value is the JSON literal null", () => {
+    localStorage.setItem("hp_profile", "null");
+    expect(loadProfile()).toEqual({});
+  });
+
+  it("returns an empty object when the stored value is an array", () => {
+    localStorage.setItem("hp_profile", "[1,2,3]");
+    expect(loadProfile()).toEqual({});
+  });
+
+  it("returns an empty object when the stored value is a primitive", () => {
+    localStorage.setItem("hp_profile", "42");
+    expect(loadProfile()).toEqual({});
+  });
+});

--- a/test/route-line.test.js
+++ b/test/route-line.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { buildRouteFeature } from "../src/pages/Help.jsx";
+
+// ---------------------------------------------------------------------------
+// buildRouteFeature() tests
+//
+// RouteLine memoizes on this builder instead of allocating a new GeoJSON
+// object every render. These tests verify the builder itself stays correct
+// (lng/lat order, structure) independent of the memoization.
+// ---------------------------------------------------------------------------
+
+describe("buildRouteFeature", () => {
+  it("builds a GeoJSON LineString Feature", () => {
+    const feature = buildRouteFeature([10, 20], [30, 40]);
+    expect(feature.type).toBe("Feature");
+    expect(feature.geometry.type).toBe("LineString");
+  });
+
+  it("converts [lat, lng] input into [lng, lat] coordinate pairs", () => {
+    const feature = buildRouteFeature([10, 20], [30, 40]);
+    expect(feature.geometry.coordinates).toEqual([
+      [20, 10],
+      [40, 30],
+    ]);
+  });
+
+  it("returns a fresh object each call (no shared mutable state)", () => {
+    const a = buildRouteFeature([10, 20], [30, 40]);
+    const b = buildRouteFeature([10, 20], [30, 40]);
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
+
+  it("reflects updated coordinates on the next call", () => {
+    const first = buildRouteFeature([1, 2], [3, 4]);
+    const second = buildRouteFeature([5, 6], [7, 8]);
+    expect(first.geometry.coordinates).toEqual([
+      [2, 1],
+      [4, 3],
+    ]);
+    expect(second.geometry.coordinates).toEqual([
+      [6, 5],
+      [8, 7],
+    ]);
+  });
+});


### PR DESCRIPTION
  ## Summary

  Closes #226, Closes #227, Closes #228, Closes #229

  - **#226** — `distance()` (the haversine helper that uses `sinLng`) now guards
    against non-finite/missing coordinates, returning `null` instead of
    silently producing `NaN`. The one call site that wasn't already
    finite-checked ("… km away" in the tracking sidebar) now hides that line
    instead of rendering `NaN km away`.
  - **#227** — `RouteLine`'s GeoJSON is now built by a pure `buildRouteFeature()`
    helper and memoized with `useMemo` on the route's coordinates, so it isn't
    reallocated on every render.
  - **#228** — `loadProfile()` now validates that the parsed `localStorage`
    value is a plain object before returning it, so malformed data (`null`,
    an array, a bare number) can't crash the `.nickname`/`.contact` reads that
    consume it.
  - **#229** — `DEFAULT_CENTER` is now `Object.freeze`d so the shared fallback
    map-center array can't be mutated in place.

  ## Test plan
  - Added `test/distance.test.js`, `test/route-line.test.js`,
    `test/load-profile.test.js`, `test/default-center.test.js`
  - `npm test` → 14 test files, 284 tests, all passing
  - `npm run build` → succeeds
