### PR TITLE
fix: validate contract IDs, guard Ranking against stale async state, …

### DIFF
--- a/src/lib/contract.js
+++ b/src/lib/contract.js
@@ -1,10 +1,27 @@
 import {
   rpc, Contract, TransactionBuilder, Operation, Transaction, Account, Keypair,
-  nativeToScVal, scValToNative, Networks, BASE_FEE,
+  nativeToScVal, scValToNative, Networks, BASE_FEE, StrKey,
 } from '@stellar/stellar-sdk'
 
-const DEFAULT_CONTRACT_ID = 'CDP5XZ7UYCGSQBYRDYM2OEAUQJULBZPULSQXK7LGNAJTRXRG3VHZLSHY'
-const CONTRACT_ID = import.meta.env?.VITE_HELPHONE_CONTRACT_ID || DEFAULT_CONTRACT_ID
+/** Validate a Stellar Soroban contract ID (strkey 'C...' with CRC16 checksum).
+ *  Throws immediately with a clear message instead of letting a malformed ID
+ *  silently propagate into RPC calls, where it would surface later as an
+ *  opaque simulation/network failure. */
+export function assertValidContractId(id, label) {
+  if (typeof id !== 'string' || !StrKey.isValidContract(id)) {
+    throw new Error(`${label} is not a valid Stellar contract ID: ${JSON.stringify(id)}`)
+  }
+  return id
+}
+
+const DEFAULT_CONTRACT_ID = assertValidContractId(
+  'CDP5XZ7UYCGSQBYRDYM2OEAUQJULBZPULSQXK7LGNAJTRXRG3VHZLSHY',
+  'DEFAULT_CONTRACT_ID'
+)
+const CONTRACT_ID = assertValidContractId(
+  import.meta.env?.VITE_HELPHONE_CONTRACT_ID || DEFAULT_CONTRACT_ID,
+  'CONTRACT_ID'
+)
 const RPC_URL = 'https://soroban-testnet.stellar.org'
 const DEFAULT_FRIENDBOT_URL = 'https://friendbot.stellar.org'
 const FRIENDBOT_URL = import.meta.env?.VITE_FRIENDBOT_URL || DEFAULT_FRIENDBOT_URL

--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -539,6 +539,25 @@ function Step({ n, title, subtitle, done, active, children }) {
   );
 }
 
+export const HELP_ONBOARDING_STEPS = [
+  {
+    label: "Request",
+    title: "Help when you need it",
+    body: "HelPhone connects you with people nearby when you're in an emergency. You can request help or offer help to others. Everything runs on Stellar — fast, public, and verifiable.",
+  },
+  {
+    label: "Receipt",
+    title: "Your action goes on-chain first",
+    body: "When you request or offer help, Stellar confirms it in seconds. That creates a public transaction hash — your receipt.",
+  },
+  {
+    label: "Wallet",
+    title: "Connect your preferred wallet",
+    body: "Your Stellar wallet only signs transactions — it's not a tracking tool. Connect to request help, offer help, or verify your identity on the network.",
+    isLast: true,
+  },
+];
+
 function HelpOnboardingModal({ open, onClose, onConnectWallet }) {
   const [step, setStep] = useState(0);
   useEffect(() => {
@@ -547,26 +566,8 @@ function HelpOnboardingModal({ open, onClose, onConnectWallet }) {
 
   if (!open) return null;
 
-  const totalSteps = 3;
-
-  const steps = [
-    {
-      label: "Request",
-      title: "Help when you need it",
-      body: "HelPhone connects you with people nearby when you're in an emergency. You can request help or offer help to others. Everything runs on Stellar — fast, public, and verifiable.",
-    },
-    {
-      label: "Receipt",
-      title: "Your action goes on-chain first",
-      body: "When you request or offer help, Stellar confirms it in seconds. That creates a public transaction hash — your receipt.",
-    },
-    {
-      label: "Wallet",
-      title: "Connect your preferred wallet",
-      body: "Your Stellar wallet only signs transactions — it's not a tracking tool. Connect to request help, offer help, or verify your identity on the network.",
-      isLast: true,
-    },
-  ];
+  const steps = HELP_ONBOARDING_STEPS;
+  const totalSteps = steps.length;
 
   const current = steps[Math.min(step, steps.length - 1)];
 

--- a/src/pages/Ranking.jsx
+++ b/src/pages/Ranking.jsx
@@ -12,20 +12,25 @@ export default function Ranking() {
   const [period, setPeriod] = useState('All Time')
 
   useEffect(() => {
+    let ignore = false
     async function load() {
       setLoading(true)
       try {
         const entries = await getRanking()
+        if (ignore) return
         const sorted = entries
           .sort((a, b) => b.total_arrivals - a.total_arrivals)
           .slice(0, 20)
         setRows(sorted)
       } catch {
-        setRows([])
+        if (!ignore) setRows([])
       }
-      setLoading(false)
+      if (!ignore) setLoading(false)
     }
     load()
+    return () => {
+      ignore = true
+    }
   }, [period])
 
   return (

--- a/test/contract-id-validation.test.js
+++ b/test/contract-id-validation.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { assertValidContractId } from '../src/lib/contract'
+
+// ---------------------------------------------------------------------------
+// Issues #329 / #330 — DEFAULT_CONTRACT_ID / CONTRACT_ID hardening
+//
+// A malformed contract ID used to propagate silently into the Contract()
+// constructor and only fail later as an opaque RPC/simulation error.
+// assertValidContractId() fails fast with a clear message instead.
+// ---------------------------------------------------------------------------
+
+const VALID_CONTRACT_ID = 'CDP5XZ7UYCGSQBYRDYM2OEAUQJULBZPULSQXK7LGNAJTRXRG3VHZLSHY'
+
+describe('assertValidContractId', () => {
+  it('returns a well-formed contract ID unchanged', () => {
+    expect(assertValidContractId(VALID_CONTRACT_ID, 'TEST_ID')).toBe(VALID_CONTRACT_ID)
+  })
+
+  it('accepts the deployed default contract ID (DEFAULT_CONTRACT_ID)', () => {
+    expect(VALID_CONTRACT_ID).toHaveLength(56)
+    expect(() => assertValidContractId(VALID_CONTRACT_ID, 'DEFAULT_CONTRACT_ID')).not.toThrow()
+  })
+
+  it('throws on a wallet G-address instead of a contract C-address', () => {
+    const gAddress = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3'
+    expect(() => assertValidContractId(gAddress, 'CONTRACT_ID')).toThrow(/not a valid Stellar contract ID/)
+  })
+
+  it('throws on a truncated contract ID', () => {
+    expect(() => assertValidContractId(VALID_CONTRACT_ID.slice(0, 40), 'CONTRACT_ID')).toThrow()
+  })
+
+  it('throws on a contract ID with invalid base32 characters', () => {
+    const invalid = 'C' + '1'.repeat(55) // '1' and '0' are not valid base32 digits
+    expect(() => assertValidContractId(invalid, 'CONTRACT_ID')).toThrow()
+  })
+
+  it('throws on a same-length, same-charset typo that fails the CRC16 checksum', () => {
+    // Last character flipped: still 56 chars, still [A-Z2-7], but the strkey checksum no longer matches.
+    const typo = VALID_CONTRACT_ID.slice(0, -1) + (VALID_CONTRACT_ID.endsWith('Y') ? 'X' : 'Y')
+    expect(() => assertValidContractId(typo, 'CONTRACT_ID')).toThrow()
+  })
+
+  it('throws on non-string input (null, undefined, number)', () => {
+    expect(() => assertValidContractId(null, 'CONTRACT_ID')).toThrow()
+    expect(() => assertValidContractId(undefined, 'CONTRACT_ID')).toThrow()
+    expect(() => assertValidContractId(12345, 'CONTRACT_ID')).toThrow()
+  })
+
+  it('throws on an empty string', () => {
+    expect(() => assertValidContractId('', 'CONTRACT_ID')).toThrow()
+  })
+
+  it('includes the provided label in the error message', () => {
+    expect(() => assertValidContractId('bad', 'CONTRACT_ID')).toThrow(/CONTRACT_ID/)
+  })
+})

--- a/test/help-onboarding-steps.test.js
+++ b/test/help-onboarding-steps.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { HELP_ONBOARDING_STEPS } from "../src/pages/Help.jsx";
+
+// ---------------------------------------------------------------------------
+// Issue #242 — HelpOnboardingModal totalSteps hardcoded magic number
+//
+// totalSteps used to be a hardcoded literal (3) tracked separately from the
+// steps array, so editing one without the other would silently desync the
+// progress dots / "N of totalSteps" label / final-step CTA. totalSteps is
+// now always derived from HELP_ONBOARDING_STEPS.length.
+// ---------------------------------------------------------------------------
+
+describe("HELP_ONBOARDING_STEPS", () => {
+  it("is a non-empty array of step definitions", () => {
+    expect(Array.isArray(HELP_ONBOARDING_STEPS)).toBe(true);
+    expect(HELP_ONBOARDING_STEPS.length).toBeGreaterThan(0);
+  });
+
+  it("each step has a label, title, and body", () => {
+    HELP_ONBOARDING_STEPS.forEach((step) => {
+      expect(typeof step.label).toBe("string");
+      expect(typeof step.title).toBe("string");
+      expect(typeof step.body).toBe("string");
+    });
+  });
+
+  it("marks only the final step as isLast", () => {
+    const lastIndex = HELP_ONBOARDING_STEPS.length - 1;
+    HELP_ONBOARDING_STEPS.forEach((step, i) => {
+      if (i === lastIndex) {
+        expect(step.isLast).toBe(true);
+      } else {
+        expect(step.isLast).toBeFalsy();
+      }
+    });
+  });
+
+  it("derived totalSteps tracks the array length with no separate constant", () => {
+    const totalSteps = HELP_ONBOARDING_STEPS.length;
+    expect(totalSteps).toBe(HELP_ONBOARDING_STEPS.length);
+
+    // Simulates adding/removing a step: totalSteps must move with it automatically.
+    const withExtraStep = [...HELP_ONBOARDING_STEPS, { label: "Extra", title: "t", body: "b" }];
+    expect(withExtraStep.length).toBe(totalSteps + 1);
+  });
+});

--- a/test/ranking-race-condition.test.js
+++ b/test/ranking-race-condition.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Issue #328 — Ranking.jsx race condition in asynchronous state
+//
+// Switching the period tab quickly re-triggers the effect before the prior
+// getRanking() call resolves. Out-of-order resolution used to let a stale
+// response overwrite the latest one. This simulates the hardened effect
+// (stale-response guard via a per-run `ignore` flag) from Ranking.jsx.
+// ---------------------------------------------------------------------------
+
+function makeEntries(tag) {
+  return [{ responder: `G${tag}`, total_arrivals: 1 }]
+}
+
+function runEffect(getRanking, setRows, setLoading) {
+  let ignore = false
+  async function load() {
+    setLoading(true)
+    try {
+      const entries = await getRanking()
+      if (ignore) return
+      const sorted = entries
+        .sort((a, b) => b.total_arrivals - a.total_arrivals)
+        .slice(0, 20)
+      setRows(sorted)
+    } catch {
+      if (!ignore) setRows([])
+    }
+    if (!ignore) setLoading(false)
+  }
+  load()
+  return () => {
+    ignore = true
+  }
+}
+
+describe('Ranking effect — stale response guard', () => {
+  it('does not let a slow first call overwrite a fast second call', async () => {
+    const rows = []
+    const setRows = vi.fn((v) => rows.push(v))
+    const setLoading = vi.fn()
+
+    let resolveFirst
+    const getRanking = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise((r) => { resolveFirst = r }))
+      .mockImplementationOnce(() => Promise.resolve(makeEntries('fast')))
+
+    // First effect run (slow) — simulates selecting period A
+    const cleanupA = runEffect(getRanking, setRows, setLoading)
+    // Cleanup runs before the next effect, as React does on dependency change
+    cleanupA()
+    // Second effect run (fast) — simulates quickly selecting period B
+    runEffect(getRanking, setRows, setLoading)
+
+    // Let the fast call resolve first
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Now let the slow first call resolve after the fast one already set rows
+    resolveFirst(makeEntries('slow'))
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Only the fast (latest) response should have been committed to state
+    expect(setRows).toHaveBeenCalledTimes(1)
+    expect(setRows).toHaveBeenCalledWith(makeEntries('fast'))
+  })
+
+  it('ignores a stale rejection after cleanup', async () => {
+    const setRows = vi.fn()
+    const setLoading = vi.fn()
+
+    let rejectFirst
+    const getRanking = vi.fn().mockImplementationOnce(
+      () => new Promise((_, rej) => { rejectFirst = rej })
+    )
+
+    const cleanup = runEffect(getRanking, setRows, setLoading)
+    cleanup()
+    rejectFirst(new Error('network down'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(setRows).not.toHaveBeenCalled()
+  })
+
+  it('still commits results when no cleanup has run', async () => {
+    const setRows = vi.fn()
+    const setLoading = vi.fn()
+    const getRanking = vi.fn().mockResolvedValue(makeEntries('only'))
+
+    runEffect(getRanking, setRows, setLoading)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(setRows).toHaveBeenCalledWith(makeEntries('only'))
+  })
+})


### PR DESCRIPTION
  ## Summary

  src/pages/Help.jsx.
  
  - **Contract ID validation** (`src/lib/contract.js`): `DEFAULT_CONTRACT_ID` and `CONTRACT_ID`
  were unvalidated string constants. Added `assertValidContractId()`, which uses the Stellar
  SDK's `StrKey.isValidContract()` (full CRC16 checksum validation) to fail fast at module load
  if either value is malformed — e.g. a typo'd `VITE_HELPHONE_CONTRACT_ID` env override — instead
  of letting a bad ID silently propagate into RPC calls and surface later as a confusing
  simulation/network error.
  - **Ranking race condition** (`src/pages/Ranking.jsx`): the ranking-fetch effect had no guard
  against out-of-order async resolution. If the effect re-ran (e.g. rapid period-tab switching)
  before the previous `getRanking()` call resolved, a stale response could overwrite fresher
  data. Added the same ignore-flag cleanup guard already used elsewhere in this codebase for
  async effects.
  - **Onboarding step count** (`src/pages/Help.jsx`): `HelpOnboardingModal` tracked `totalSteps =
  3` as a hardcoded literal separate from the `steps` array (also length 3). Extracted `steps`
  to an exported module-level constant (`HELP_ONBOARDING_STEPS`) and derived `totalSteps` from
  its length, removing the duplicate source of truth.
  
  ## Testing
  
  - Added `test/contract-id-validation.test.js`, `test/ranking-race-condition.test.js`,
  `test/help-onboarding-steps.test.js`
  - `npm run test` — 280/280 passing
  - `npm run build` — succeeds
  
  Closes #329
  Closes #330
  Closes #328
  Closes #242
