### PR TITLE
Fix NaN request-id collisions, stale autocomplete race, unvalidated ZK public inputs, and unvalidated geolocation

### DIFF
--- a/src/lib/zk.js
+++ b/src/lib/zk.js
@@ -332,17 +332,38 @@ function getOrCreateSecret() {
   return secret
 }
 
+// Each public input must fit in a single 32-byte BE field. A value outside
+// [0, 2^256) would overflow the fixed-width slice below and silently drop
+// its high-order bytes instead of throwing — corrupting the encoded public
+// inputs the contract verifies against. Values sourced from the ZK prover
+// server response (e.g. the nullifier) are untrusted network input and must
+// be checked here before encoding, not assumed well-formed.
+const UINT256_MAX = (1n << 256n) - 1n
+
+function parseFieldElement(value, label) {
+  let big
+  try {
+    big = BigInt(value)
+  } catch {
+    throw new Error(`${label} is not a valid integer: ${JSON.stringify(value)}`)
+  }
+  if (big < 0n || big > UINT256_MAX) {
+    throw new Error(`${label} is out of range for a 32-byte field element: ${value}`)
+  }
+  return big
+}
+
 // Build 224-byte public inputs buffer for aegis_vault.claim_aid (7 × 32-byte BE fields)
 // Layout: box_x_min | box_x_max | box_y_min | box_y_max | campaign_id | recipient_address | nullifier
 function buildPublicInputsBytes(boxXMin, boxXMax, boxYMin, boxYMax, campaignId, recipientField, nullifier) {
   const fields = [
-    BigInt(boxXMin),
-    BigInt(boxXMax),
-    BigInt(boxYMin),
-    BigInt(boxYMax),
-    BigInt(campaignId),
-    BigInt(recipientField),
-    BigInt(nullifier),
+    parseFieldElement(boxXMin, 'box_x_min'),
+    parseFieldElement(boxXMax, 'box_x_max'),
+    parseFieldElement(boxYMin, 'box_y_min'),
+    parseFieldElement(boxYMax, 'box_y_max'),
+    parseFieldElement(campaignId, 'campaign_id'),
+    parseFieldElement(recipientField, 'recipient_address'),
+    parseFieldElement(nullifier, 'nullifier'),
   ]
   const buf = new Uint8Array(224)
   fields.forEach((f, i) => {

--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -1617,6 +1617,11 @@ export default function Help() {
   const [activeSuggestion, setActiveSuggestion] = useState(-1);
   const searchBoxRef = useRef(null);
   const searchAbortRef = useRef(null);
+  // Lets the outside-click handler cancel the in-flight autocomplete fetch.
+  // Without this, a slow/timed-out request that resolves after the user
+  // dismisses the dropdown would silently repopulate suggestions they
+  // already closed.
+  const searchSuggestTokenRef = useRef(null);
 
   // Clean up searchBoxRef on unmount to prevent memory leaks (#253)
   useEffect(() => {
@@ -1783,6 +1788,7 @@ export default function Help() {
     }
 
     const token = cancellationToken();
+    searchSuggestTokenRef.current = token;
     const timeout = setTimeout(async () => {
       try {
         setSearchSuggestLoading(true);
@@ -1813,6 +1819,10 @@ export default function Help() {
     if (searchSuggestions.length === 0) return;
     function onPointerDown(e) {
       if (searchBoxRef.current && !searchBoxRef.current.contains(e.target)) {
+        // Cancel the in-flight autocomplete request too, otherwise a slow
+        // response landing after dismissal silently reopens the dropdown.
+        searchSuggestTokenRef.current?.cancel();
+        setSearchSuggestLoading(false);
         setSearchSuggestions([]);
         setActiveSuggestion(-1);
       }
@@ -1873,15 +1883,36 @@ export default function Help() {
     setLocationError("");
     navigator.geolocation.getCurrentPosition(
       (pos) => {
-        setLocation([pos.coords.latitude, pos.coords.longitude]);
         setLocating(false);
+        const lat = pos.coords.latitude;
+        const lng = pos.coords.longitude;
+        // Reject out-of-range/non-finite coordinates here instead of
+        // letting them reach encodeCoord() during a contract write, where
+        // an out-of-range value throws deep inside a pending transaction
+        // rather than failing at acquisition time with a clear message.
+        const valid =
+          Number.isFinite(lat) &&
+          Number.isFinite(lng) &&
+          lat >= -90 &&
+          lat <= 90 &&
+          lng >= -180 &&
+          lng <= 180;
+        if (!valid) {
+          setLocationError(
+            "Received an invalid location. Search by city, or click the map to drop a pin.",
+          );
+          return;
+        }
+        setLocation([lat, lng]);
       },
       (err) => {
         setLocating(false);
         setLocationError(
           err.code === 1
             ? "Location blocked. Search by city, or click the map to drop a pin."
-            : "Could not get location. Search below or click the map.",
+            : err.code === 3
+              ? "Location request timed out. Search below or click the map."
+              : "Could not get location. Search below or click the map.",
         );
       },
       { timeout: 12000 },

--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -2083,9 +2083,13 @@ export default function Help() {
     dispatchZk({ type: "RESET" });
   }
 
-  // O(1) removal: Map keyed by numeric id — no linear scan
+  // O(1) removal: Map keyed by numeric id — no linear scan.
+  // NaN is rejected up front: every unparseable id would otherwise coerce to
+  // the same NaN key, so distinct requests could collide and clobber or
+  // remove each other's state (a request from one id evicting another's).
   function removeOpenRequest(reqId) {
     const key = Number(reqId);
+    if (!Number.isFinite(key)) return;
     setSelectedRequest((current) =>
       Number(current?.id) === key ? null : current,
     );
@@ -2099,7 +2103,8 @@ export default function Help() {
 
   function syncOpenRequest(reqId, fresh) {
     const key = Number(reqId);
-    const request = { ...fresh, id: reqId };
+    if (!Number.isFinite(key)) return null;
+    const request = { ...fresh, id: key };
     setOpenRequests((prev) => {
       const next = new Map(prev);
       next.set(key, request);
@@ -2128,16 +2133,21 @@ export default function Help() {
   const _refreshLocks = new Map();
 
   async function refreshPendingRequest(reqId) {
+    // Normalize before locking/keying: a raw reqId can arrive as a string or
+    // number for the same request, and coercing only after the lock check
+    // let concurrent refreshes of the same id race past this guard.
+    const key = Number(reqId);
+    if (!Number.isFinite(key)) return null;
     // Prevent concurrent refreshes of same request to avoid race conditions
-    if (_refreshLocks.has(reqId)) {
+    if (_refreshLocks.has(key)) {
       return null;
     }
-    _refreshLocks.set(reqId, true);
+    _refreshLocks.set(key, true);
 
     try {
-      const fresh = await getRequest(reqId);
+      const fresh = await getRequest(key);
       if (!fresh || fresh.status !== "Pending") {
-        removeOpenRequest(reqId);
+        removeOpenRequest(key);
         // Non-blocking error handling to prevent main thread blocking
         // and smart contract access control bypass
         setRequestError(requestUnavailableMessage(fresh));
@@ -2147,9 +2157,9 @@ export default function Help() {
       }
       // Clear any previous error on successful refresh
       setRequestError("");
-      return syncOpenRequest(reqId, fresh);
+      return syncOpenRequest(key, fresh);
     } finally {
-      _refreshLocks.delete(reqId);
+      _refreshLocks.delete(key);
     }
   }
 


### PR DESCRIPTION
closes #282 - Overhaul fresh in Help.jsx
syncOpenRequest/removeOpenRequest/refreshPendingRequest keyed the open-requests
Map on Number(reqId) without checking for NaN. Any unparseable/precision-lost id
coerces to the same NaN key, so unrelated requests could collide and silently
overwrite or evict each other's state.

closes #265 - Overhaul onPointerDown in Help.jsx
Dismissing the search-suggestions dropdown via outside click never cancelled the
in-flight Mapbox autocomplete fetch. A slow request resolving after dismissal
would silently repopulate suggestions the user had already closed.

closes #264 - Overhaul data in zk.js
buildPublicInputsBytes ran BigInt() on the ZK prover server's raw response
(including the nullifier) with no range check. An out-of-field-range or
malformed value would silently truncate to the wrong 32-byte field during
encoding, corrupting the public inputs the contract verifies the proof against.

closes #269 - Overhaul requestLocation in Help.jsx
requestLocation passed raw geolocation coords straight into state with only a
finite-number check downstream. An out-of-range coordinate would pass that check
and only fail later, deep inside a contract write (encodeCoord throws there)
instead of failing fast with a clear message at acquisition time.
