### PR TITLE
Harden request polling, data validation, and dropdown handlers in Help/Ranking

### DIFF
--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -1594,6 +1594,20 @@ export function safeToggleClass(
   return false;
 }
 
+function useOutsideClick(active, ref, onOutside) {
+  useEffect(() => {
+    if (!active) return;
+    function onDocClick(e) {
+      const target = e.target instanceof Node ? e.target : null;
+      if (target && ref.current && !ref.current.contains(target)) {
+        onOutside();
+      }
+    }
+    document.addEventListener("click", onDocClick, { passive: true });
+    return () => document.removeEventListener("click", onDocClick);
+  }, [active, ref, onOutside]);
+}
+
 export default function Help() {
   const [mode, setMode] = useState("get");
 
@@ -1747,35 +1761,17 @@ export default function Help() {
     safeToggleClass(sidebarRef.current, showMobileForm);
   }, [showMobileForm]);
 
-  useEffect(() => {
-    if (!styleOpen) return;
-    function onDocClick(e) {
-      const target = e.target instanceof Node ? e.target : null;
-      if (
-        target &&
-        styleSelectorRef.current &&
-        !styleSelectorRef.current.contains(target)
-      )
-        setStyleOpen(false);
-    }
-    document.addEventListener("click", onDocClick, { passive: true });
-    return () => document.removeEventListener("click", onDocClick);
-  }, [styleOpen]);
+  useOutsideClick(
+    styleOpen,
+    styleSelectorRef,
+    useCallback(() => setStyleOpen(false), []),
+  );
 
-  useEffect(() => {
-    if (!profileOpen) return;
-    function onDocClick(e) {
-      const target = e.target instanceof Node ? e.target : null;
-      if (
-        target &&
-        profileRef.current &&
-        !profileRef.current.contains(target)
-      )
-        setProfileOpen(false);
-    }
-    document.addEventListener("click", onDocClick, { passive: true });
-    return () => document.removeEventListener("click", onDocClick);
-  }, [profileOpen]);
+  useOutsideClick(
+    profileOpen,
+    profileRef,
+    useCallback(() => setProfileOpen(false), []),
+  );
 
   useEffect(() => {
     localStorage.setItem("hp_profile", JSON.stringify(profile));
@@ -1839,10 +1835,15 @@ export default function Help() {
     if (mode !== "offer") return;
     const token = cancellationToken();
     let loading = false;
+    let timer = null;
+    const BASE_DELAY_MS = 5000;
+    const MAX_DELAY_MS = 60000;
+    let consecutiveFailures = 0;
 
     async function load() {
       if (loading) return;
       loading = true;
+      let failed = false;
       try {
         const ids = await getActiveRequests();
         const requests = await Promise.all(
@@ -1862,15 +1863,24 @@ export default function Help() {
             return map.get(Number(current.id)) || null;
           });
         }
-      } catch (_) {}
+      } catch (_) {
+        failed = true;
+      }
       loading = false;
+
+      consecutiveFailures = failed ? consecutiveFailures + 1 : 0;
+      const delay = failed
+        ? Math.min(BASE_DELAY_MS * 2 ** consecutiveFailures, MAX_DELAY_MS)
+        : BASE_DELAY_MS;
+      if (token.active) {
+        timer = setTimeout(load, delay);
+      }
     }
 
     load();
-    const interval = setInterval(load, 5000);
     return () => {
       token.cancel();
-      clearInterval(interval);
+      if (timer) clearTimeout(timer);
     };
   }, [mode]);
 
@@ -2636,7 +2646,12 @@ export default function Help() {
           ids.map((id) => getRequest(id).catch(() => null)),
         );
         const filtered = results.filter(
-          (r) => r && r.requester === activeWalletAddress,
+          (r) =>
+            r &&
+            typeof r.requester === "string" &&
+            r.requester === activeWalletAddress &&
+            Number.isFinite(r.id) &&
+            Number.isFinite(r.created_at),
         );
         filtered.sort((a, b) => b.created_at - a.created_at);
         if (token.active) setMyRequests(filtered);

--- a/src/pages/Ranking.jsx
+++ b/src/pages/Ranking.jsx
@@ -18,7 +18,15 @@ export default function Ranking() {
       try {
         const entries = await getRanking()
         if (ignore) return
-        const sorted = entries
+        const valid = Array.isArray(entries)
+          ? entries.filter(
+              (e) =>
+                e &&
+                typeof e.responder === 'string' &&
+                Number.isFinite(e.total_arrivals),
+            )
+          : []
+        const sorted = valid
           .sort((a, b) => b.total_arrivals - a.total_arrivals)
           .slice(0, 20)
         setRows(sorted)


### PR DESCRIPTION
closes #268 - Offer-mode polling now uses exponential backoff (5s → capped at 60s) on consecutive failures instead of a fixed 5s setInterval, so a struggling RPC endpoint isn't hammered indefinitely.

closes #267 - fetchMyRequests now asserts requester/id/created_at shape before requests enter state, and the sort comparator is now NaN-safe against malformed contract reads.

closes #266 - Ranking.jsx load() now validates that getRanking() returned an array of well-formed entries (string responder, finite total_arrivals) before sorting/slicing, so a malformed response can't reach the table.

closes #263 - Deduplicated the two near-identical outside-click handlers (style selector, profile menu) into a single useOutsideClick hook.
