### PR TITLE
Make Aegis payout amount admin configurable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,9 +117,10 @@ bb write_vk -b target/aegis.json -o target/vk   # extract VK for contract deploy
 `noir_verifier` wraps `ultrahonk_rust_verifier` — deployed once, stores VK on-chain, exposes `verify_proof(public_inputs, proof_bytes)`.
 
 `aegis_vault` depends on `noir_verifier` via `{ path = "../noir_verifier" }`. Key entry points:
-- `__constructor(verifier: Address, token: Address)` — set verifier contract + USDC token.
+- `__constructor(verifier: Address, token: Address, admin: Address)` — set verifier contract, USDC token, admin, and the default 50 USDC payout.
+- `set_payout_amount(admin, amount)` / `payout_amount()` — admin-only payout configuration in token base units.
 - `fund_zone(funder, campaign_id, amount)` — pull USDC from funder.
-- `claim_aid(recipient, public_inputs: Bytes[224], proof_bytes)` — verify ZK proof, check nullifier not spent, pay 50 USDC.
+- `claim_aid(recipient, public_inputs: Bytes[224], proof_bytes)` — verify ZK proof, check nullifier not spent, pay the configured payout amount.
 - `campaign_balance(campaign_id)` / `is_claimed(nullifier)` — read-only helpers.
 
 **Public inputs layout** (224 bytes = 7 × 32 BE):

--- a/contracts/aegis_vault/src/lib.rs
+++ b/contracts/aegis_vault/src/lib.rs
@@ -17,7 +17,7 @@ use soroban_sdk::{
 // [192..224] nullifier       Poseidon2(secret_id, campaign_id) — proof return value
 const CAMPAIGN_INPUTS_LEN: usize = 160;
 const PUBLIC_INPUTS_LEN: usize = 224;
-const PAYOUT_STROOP: i128 = 50 * 10_000_000; // 50 USDC (7 decimals)
+const DEFAULT_PAYOUT_STROOP: i128 = 50 * 10_000_000; // 50 USDC (7 decimals)
 const BN254_FIELD_PRIME: [u8; 32] = [
     0x30, 0x64, 0x4e, 0x72, 0xe1, 0x31, 0xa0, 0x29,
     0xb8, 0x50, 0x45, 0xb6, 0x81, 0x81, 0x58, 0x5d,
@@ -40,6 +40,8 @@ pub enum VaultError {
     TokenNotSet = 6,
     RecipientMismatch = 7,
     Overflow = 8,
+    NotAuthorized = 9,
+    InvalidPayout = 10,
 }
 
 #[contractevent(topics = ["claimed"], data_format = "map")]
@@ -60,9 +62,18 @@ pub struct FundedEvent<'a> {
 
 fn key_verifier()  -> Symbol { symbol_short!("verifier") }
 fn key_token()     -> Symbol { symbol_short!("token") }
+fn key_admin()     -> Symbol { symbol_short!("admin") }
+fn key_payout()    -> Symbol { symbol_short!("payout") }
 fn key_nullifier_prefix() -> Symbol { symbol_short!("nf") }
 fn key_campaign_prefix()  -> Symbol { symbol_short!("camp") }
 fn key_zone_prefix()      -> Symbol { symbol_short!("zone") }
+
+fn payout_amount(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&key_payout())
+        .unwrap_or(DEFAULT_PAYOUT_STROOP)
+}
 
 fn parse_public_inputs(
     env: &Env,
@@ -159,10 +170,40 @@ impl AegisVault {
         env: Env,
         verifier: Address,
         token: Address,
+        admin: Address,
     ) -> Result<(), VaultError> {
         env.storage().instance().set(&key_verifier(), &verifier);
         env.storage().instance().set(&key_token(), &token);
+        env.storage().instance().set(&key_admin(), &admin);
+        env.storage().instance().set(&key_payout(), &DEFAULT_PAYOUT_STROOP);
         Ok(())
+    }
+
+    /// Update the aid payout amount in token base units. Admin authorization is required.
+    pub fn set_payout_amount(
+        env: Env,
+        admin: Address,
+        amount: i128,
+    ) -> Result<(), VaultError> {
+        if amount <= 0 {
+            return Err(VaultError::InvalidPayout);
+        }
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&key_admin())
+            .ok_or(VaultError::NotAuthorized)?;
+        if admin != stored_admin {
+            return Err(VaultError::NotAuthorized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&key_payout(), &amount);
+        Ok(())
+    }
+
+    /// Returns the current aid payout amount in token base units.
+    pub fn payout_amount(env: Env) -> i128 {
+        payout_amount(&env)
     }
 
     /// Fund a campaign zone. Transfers `amount` USDC from funder to this contract.
@@ -251,7 +292,8 @@ impl AegisVault {
         let balance: i128 = env
             .storage().instance().get(&camp_key)
             .unwrap_or(0i128);
-        if balance < PAYOUT_STROOP {
+        let payout = payout_amount(&env);
+        if balance < payout {
             return Err(VaultError::InsufficientFunds);
         }
         let zone_key = (key_zone_prefix(), campaign_id.clone());
@@ -272,13 +314,13 @@ impl AegisVault {
         env.storage().instance().set(&nf_key, &true);
 
         // Deduct from campaign balance and pay recipient.
-        env.storage().instance().set(&camp_key, &(balance - PAYOUT_STROOP));
+        env.storage().instance().set(&camp_key, &(balance - payout));
 
         let token_addr: Address = env
             .storage().instance().get(&key_token())
             .ok_or(VaultError::TokenNotSet)?;
         let token_client = token::TokenClient::new(&env, &token_addr);
-        token_client.transfer(&env.current_contract_address(), &recipient, &PAYOUT_STROOP);
+        token_client.transfer(&env.current_contract_address(), &recipient, &payout);
 
         ClaimedEvent {
             campaign_id: &campaign_id,
@@ -306,10 +348,29 @@ impl AegisVault {
 #[cfg(test)]
 mod test {
     use super::*;
+    use soroban_sdk::testutils::Address as _;
 
     #[test]
     fn test_vault_error_overflow() {
         let err = VaultError::Overflow;
         assert_eq!(err as u32, 8);
+    }
+
+    #[test]
+    fn admin_can_update_payout_amount() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let verifier = Address::generate(&env);
+        let token = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let contract_id = env.register(AegisVault, (&verifier, &token, &admin));
+        let client = AegisVaultClient::new(&env, &contract_id);
+
+        assert_eq!(client.payout_amount(), DEFAULT_PAYOUT_STROOP);
+
+        client.set_payout_amount(&admin, &75_000_000);
+
+        assert_eq!(client.payout_amount(), 75_000_000);
     }
 }

--- a/docs/stellar-zk-runbook.md
+++ b/docs/stellar-zk-runbook.md
@@ -56,6 +56,11 @@ RUSTC=/Users/paukoh/.cargo/bin/rustc /Users/paukoh/.cargo/bin/cargo build --targ
 
 ## Aegis Funding Flow
 
+Deploy `aegis_vault` with the verifier contract, reward token, and payout admin
+address. The constructor initializes the responder payout to 50 USDC in token
+base units. The admin can later call `set_payout_amount(admin, amount)` to adjust
+the payout for emergency severity, token price changes, or governance decisions.
+
 `aegis_vault.fund_zone` now requires the 160-byte campaign prefix:
 
 ```text


### PR DESCRIPTION
## Summary
- Store the Aegis aid payout amount in instance storage with a 50 USDC default.
- Add an admin-only `set_payout_amount(admin, amount)` entry point plus a read-only `payout_amount()` helper.
- Use the configured payout when validating campaign balance, deducting funds, and transferring aid.
- Update the local Aegis docs/runbook for the constructor/admin payout flow.

Fixes #19

## Validation
- `git diff --check`
- Static search for stale `PAYOUT_STROOP` / old constructor references
- `cargo test` could not be run in my environment because `cargo` is not installed (`command not found`).

## Payout
Preferred payout: USDC. Please confirm the payout network/address format you want before sending funds.