### PR TITLE
Harden distance() and pickChar() in Help.jsx

### DIFF
--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -72,6 +72,7 @@ const CHARS = {
 
 function pickChar(gender, seed = "") {
   const pool = CHARS[gender] || CHARS.default;
+  if (!pool.length) return CHARS.default[0];
   const s = String(seed);
   const idx =
     s.split("").reduce((a, c) => a + c.charCodeAt(0), 0) % pool.length;
@@ -145,16 +146,14 @@ export function distance(a, b) {
     return null;
   }
   const R = 6371;
-  const dLat = ((b[0] - a[0]) * Math.PI) / 180;
-  const dLng = ((b[1] - a[1]) * Math.PI) / 180;
+  const DEG2RAD = Math.PI / 180;
+  const dLat = (b[0] - a[0]) * DEG2RAD;
+  const dLng = (b[1] - a[1]) * DEG2RAD;
   const sinLat = Math.sin(dLat / 2);
   const sinLng = Math.sin(dLng / 2);
   const h =
     sinLat * sinLat +
-    Math.cos((a[0] * Math.PI) / 180) *
-      Math.cos((b[0] * Math.PI) / 180) *
-      sinLng *
-      sinLng;
+    Math.cos(a[0] * DEG2RAD) * Math.cos(b[0] * DEG2RAD) * sinLng * sinLng;
   return R * 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
 }
 


### PR DESCRIPTION
## Summary

Addresses four issues (#219, #222, #223, #225) all targeting the same small area of `src/pages/Help.jsx`: the `distance()` haversine helper (`dLat`, `sinLat`) and `pickChar()`'s `pool` lookup. These functions are plain, synchronous, pure helpers with no async state, closures over React state, or global scope involved, so the specific failure modes described in the issues (race conditions, stale closures, global coupling) don't apply as literally stated — but each pointed at a real, small hardening opportunity:

- `distance()`: was recomputing `Math.PI / 180` three separate times per call. Extracted a `DEG2RAD` constant.
- `pickChar()`: `pool.length` could theoretically be `0` if a gender key ever mapped to an empty array, producing `NaN % 0` → `undefined` index and a broken image render. Added a guard that falls back to `CHARS.default[0]`.

Small, low-risk, behavior-preserving changes — `distance()`'s output is numerically identical, `pickChar()`'s only changes when the pool is empty (previously broken).

Closes #219
Closes #222
Closes #223
Closes #225