### PR TITLE
Harden CHARS, pickChar, CharMarker, and MapController in Help.jsx

### DIFF
--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -63,15 +63,16 @@ const MAP_STYLES = [
   },
 ];
 
-const CHARS = {
-  male: ["runner", "pacheco", "growth", "jumping-air"],
-  female: ["chilly", "meela-pantalones", "feliz", "pondering"],
-  undisclosed: ["cube-leg", "roboto", "mechanical-love"],
-  default: ["looking-ahead", "waiting", "bueno"],
-};
+const CHARS = Object.freeze({
+  male: Object.freeze(["runner", "pacheco", "growth", "jumping-air"]),
+  female: Object.freeze(["chilly", "meela-pantalones", "feliz", "pondering"]),
+  undisclosed: Object.freeze(["cube-leg", "roboto", "mechanical-love"]),
+  default: Object.freeze(["looking-ahead", "waiting", "bueno"]),
+});
 
 function pickChar(gender, seed = "") {
   const pool = CHARS[gender] || CHARS.default;
+  if (!pool.length) return CHARS.default[0];
   const s = String(seed);
   const idx =
     s.split("").reduce((a, c) => a + c.charCodeAt(0), 0) % pool.length;
@@ -98,6 +99,12 @@ function CharMarker({
       >
         <img
           src={`/assets/chars/${charName}.png`}
+          alt=""
+          onError={(e) => {
+            if (e.currentTarget.src.endsWith(`${CHARS.default[0]}.png`))
+              return;
+            e.currentTarget.src = `/assets/chars/${CHARS.default[0]}.png`;
+          }}
           style={{
             width: 52,
             height: 52,
@@ -127,8 +134,9 @@ function CharMarker({
 function MapController({ center, zoom = 14 }) {
   const { current: map } = useMap();
   useEffect(() => {
-    if (center && map)
-      map.flyTo({ center: [center[1], center[0]], zoom, duration: 1200 });
+    if (!map || !Number.isFinite(center?.[0]) || !Number.isFinite(center?.[1]))
+      return;
+    map.flyTo({ center: [center[1], center[0]], zoom, duration: 1200 });
   }, [center, zoom, map]);
   return null;
 }


### PR DESCRIPTION
## Summary

Addresses four issues (#217, #218, #220, #221), all pointing at small, plain helpers in `src/pages/Help.jsx` with templated descriptions (async race conditions, GC/DoS vectors, runtime panics) that don't literally apply — these are synchronous, side-effect-free helpers with no async state or network calls of their own. Each issue did point at one real, small hardening opportunity in the target code:

- **`CHARS`**: froze the object and each per-gender array so it can't be mutated at runtime.
- **`pickChar()`**: guarded against an empty character pool (`pool.length === 0` would produce `NaN % 0` → `undefined` index → broken image).
- **`CharMarker`**: the `<img>` had no `alt` text and no error handling — a missing/failed character PNG rendered as a permanently broken image icon with no fallback. Added `alt=""` and an `onError` handler that falls back to the default character.
- **`MapController`**: the effect called `map.flyTo` for any truthy `center`, including malformed values; now guards on both coordinates being finite numbers before flying the map, consistent with the existing `distance()` guard elsewhere in the file.

All changes are small and behavior-preserving for the valid-input path.

Closes #217
Closes #218
Closes #220
Closes #221