### PR TITLE
feat: show wallet xlm balance

### DIFF
--- a/src/lib/contract.js
+++ b/src/lib/contract.js
@@ -27,6 +27,7 @@ export const HELPHONE_NETWORKS = {
     label: 'Testnet',
     networkPassphrase: Networks.TESTNET,
     rpcUrl: import.meta.env?.VITE_STELLAR_TESTNET_RPC_URL || 'https://soroban-testnet.stellar.org',
+    horizonUrl: import.meta.env?.VITE_STELLAR_TESTNET_HORIZON_URL || 'https://horizon-testnet.stellar.org',
     contractId: import.meta.env?.VITE_HELPHONE_TESTNET_CONTRACT_ID || import.meta.env?.VITE_HELPHONE_CONTRACT_ID || DEFAULT_CONTRACT_ID,
     friendbotUrl: import.meta.env?.VITE_FRIENDBOT_URL || DEFAULT_FRIENDBOT_URL,
   },
@@ -34,6 +35,7 @@ export const HELPHONE_NETWORKS = {
     label: 'Futurenet',
     networkPassphrase: Networks.FUTURENET,
     rpcUrl: import.meta.env?.VITE_STELLAR_FUTURENET_RPC_URL || 'https://rpc-futurenet.stellar.org',
+    horizonUrl: import.meta.env?.VITE_STELLAR_FUTURENET_HORIZON_URL || 'https://horizon-futurenet.stellar.org',
     contractId: import.meta.env?.VITE_HELPHONE_FUTURENET_CONTRACT_ID || DEFAULT_CONTRACT_ID,
     friendbotUrl: import.meta.env?.VITE_FUTURENET_FRIENDBOT_URL || '',
   },
@@ -41,6 +43,7 @@ export const HELPHONE_NETWORKS = {
     label: 'Mainnet',
     networkPassphrase: Networks.PUBLIC,
     rpcUrl: import.meta.env?.VITE_STELLAR_MAINNET_RPC_URL || 'https://mainnet.sorobanrpc.com',
+    horizonUrl: import.meta.env?.VITE_STELLAR_MAINNET_HORIZON_URL || 'https://horizon.stellar.org',
     contractId: import.meta.env?.VITE_HELPHONE_MAINNET_CONTRACT_ID || import.meta.env?.VITE_HELPHONE_CONTRACT_ID || DEFAULT_CONTRACT_ID,
     friendbotUrl: '',
   },
@@ -388,6 +391,23 @@ export function subscribeToContractEvents(onEvent) {
   return () => es.close()
 }
 
+export async function getWalletBalances(address) {
+  if (!address) return [];
+
+  const url = new URL(`/accounts/${address}`, ACTIVE_NETWORK.horizonUrl);
+  const response = await fetch(url.toString());
+
+  if (!response.ok) {
+    if (response.status === 404) return [];
+    throw new Error('Could not load wallet balances');
+  }
+
+  const account = await response.json();
+  return (account.balances || []).map((balance) => ({
+    asset: balance.asset_type === 'native' ? 'XLM' : balance.asset_code,
+    balance: Number(balance.balance),
+  }));
+}
 export async function checkAccount(address) {
   if (!address) return false
   try {

--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -31,6 +31,7 @@ import {
   cancelRequest,
   getRanking,
   ensureAccountFunded,
+  getWalletBalances,
   updateLocation,
   recordExpertVerification,
   subscribeToContractEvents,
@@ -2854,6 +2855,30 @@ export default function Help() {
   }, [activeWalletAddress]);
 
   useEffect(() => {
+    if (!activeWalletAddress) {
+      setWalletBalances([]);
+      setWalletBalanceStatus("idle");
+      return;
+    }
+
+    const token = cancellationToken();
+    setWalletBalanceStatus("loading");
+    token
+      .wrap(getWalletBalances(activeWalletAddress))
+      .then((balances) => {
+        if (!token.active || !balances) return;
+        setWalletBalances(balances);
+        setWalletBalanceStatus("ready");
+      })
+      .catch(() => {
+        if (!token.active) return;
+        setWalletBalances([]);
+        setWalletBalanceStatus("error");
+      });
+
+    return () => token.cancel();
+  }, [activeWalletAddress]);
+  useEffect(() => {
     setTrackingRequestId(null);
     setTrackingIndex(null);
     setResponderArrived(false);
@@ -4859,6 +4884,39 @@ export default function Help() {
                       }}
                     >
                       {displayAddress}
+                    </div>
+                    <div
+                      style={{
+                        marginTop: "14px",
+                        padding: "10px 12px",
+                        borderRadius: "10px",
+                        background: "rgba(255,255,255,0.04)",
+                        border: "1px solid rgba(255,255,255,0.06)",
+                      }}
+                    >
+                      <div
+                        style={{
+                          fontSize: "10px",
+                          letterSpacing: "1.4px",
+                          color: "rgba(242,236,220,0.32)",
+                          marginBottom: "6px",
+                        }}
+                      >
+                        WALLET BALANCE
+                      </div>
+                      <div
+                        style={{
+                          fontSize: "13px",
+                          color: "rgba(242,236,220,0.76)",
+                          fontWeight: 700,
+                        }}
+                      >
+                        {walletBalanceStatus === "loading"
+                          ? "Loading..."
+                          : walletBalanceStatus === "error"
+                            ? "Balance unavailable"
+                            : `${(walletBalances.find((balance) => balance.asset === "XLM")?.balance ?? 0).toFixed(2)} XLM`}
+                      </div>
                     </div>
                   </div>
                   <button


### PR DESCRIPTION
Closes #174
Closes #173
Closes #170
Closes #169

## Summary
- Adds a Horizon balance reader for the active Stellar network.
- Loads balances for the connected wallet and surfaces the formatted XLM balance in the wallet profile dropdown.
- Clears cached balance state on disconnect and handles unavailable balance lookups without blocking the wallet UI.

## Validation
- Not run locally, per request.