### PR TITLE
chore: configure Husky pre-commit and pre-push hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run test

--- a/package.json
+++ b/package.json
@@ -11,8 +11,16 @@
     "dev:all": "node scripts/dev.mjs",
     "build": "vite build",
     "preview": "vite preview",
+    "prepare": "husky",
     "test": "vitest run",
     "test:watch": "vitest"
+  },
+  "lint-staged": {
+    "*.{js,jsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{css,md,json}": "prettier --write"
   },
   "keywords": [],
   "author": "",
@@ -25,7 +33,11 @@
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
     "@vitejs/plugin-react": "^6.0.2",
+    "eslint": "^9.0.0",
+    "husky": "^9.0.0",
     "jsdom": "^29.1.1",
+    "lint-staged": "^15.0.0",
+    "prettier": "^3.0.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.10"
   },


### PR DESCRIPTION
Closes #133
Closes #134
Closes #135
Closes #136

Add Husky pre-commit and pre-push hooks with lint-staged:

- `prepare` script runs `husky` on install
- `pre-commit` hook runs `lint-staged` — ESLint + Prettier on staged JS/JSX/CSS/JSON/MD files
- `pre-push` hook runs the full `vitest` test suite
- Added `husky`, `lint-staged`, `eslint`, and `prettier` to `devDependencies`