### PR TITLE
test: contract/zk unit suites, framework sanity test, and dynamic page titles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
+import useDocumentTitle from './lib/useDocumentTitle'
 
 export default function App() {
+  useDocumentTitle('Landing')
   const videoRef = useRef(null)
   const revealIdxRef = useRef(0)
   const [visibleElements, setVisibleElements] = useState(new Set())

--- a/src/lib/useDocumentTitle.js
+++ b/src/lib/useDocumentTitle.js
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+const APP_NAME = 'HelPhone'
+const TITLE_SUFFIX = ` | ${APP_NAME}`
+
+/** Generic document.title updater shared by every routed page.
+ *  Keeps the app name as a suffix so screen readers announce the
+ *  current page context together with the site identity. */
+export function setPageTitle(title) {
+  document.title = title ? `${title}${TITLE_SUFFIX}` : APP_NAME
+}
+
+/** Set the document title while the calling page is mounted.
+ *  Re-applies automatically when the title changes. */
+export default function useDocumentTitle(title) {
+  useEffect(() => {
+    setPageTitle(title)
+  }, [title])
+}

--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -41,6 +41,7 @@ import {
   generateLocationProof,
   shortProofId,
 } from "../lib/zk";
+import useDocumentTitle from "../lib/useDocumentTitle";
 
 const MAPBOX_TOKEN = import.meta.env.VITE_MAPBOX_TOKEN;
 
@@ -2128,6 +2129,7 @@ function AvatarSelectionModal({ open, onClose, selected, onSelect }) {
 }
 
 export default function Help() {
+  useDocumentTitle("Help");
   const [mode, setMode] = useState("get");
 
   const [profile, setProfile] = useState(() => {

--- a/src/pages/Ranking.jsx
+++ b/src/pages/Ranking.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { getRanking } from '../lib/contract'
+import useDocumentTitle from '../lib/useDocumentTitle'
 
 const PERIODS = Object.freeze(['This Week', 'This Month', 'All Time'])
 
@@ -57,6 +58,7 @@ function SkeletonRow() {
 }
 
 export default function Ranking() {
+  useDocumentTitle('Ranking')
   const [rows, setRows] = useState([])
   const [loading, setLoading] = useState(true)
   const [period, setPeriod] = useState('All Time')

--- a/test/contract-functions.test.js
+++ b/test/contract-functions.test.js
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Issue #107 — unit tests for src/lib/contract.js transaction flows
+// (`createRequest` is the emergency-submission path, `resolveRequest` the
+// emergency-resolution path).
+//
+// The Stellar SDK is partially mocked: only the Soroban RPC client
+// (`rpc.Server`) and `rpc.assembleTransaction` are replaced, so transactions
+// are really built with the production TransactionBuilder/Operation code and
+// only the network round-trips (simulate → sign → submit → poll) are faked.
+// ---------------------------------------------------------------------------
+
+const state = vi.hoisted(() => ({ servers: [] }))
+
+vi.mock('@stellar/stellar-sdk', async (importOriginal) => {
+  const actual = await importOriginal()
+
+  // Capturing fake RPC client — every method contract.js touches is a vi.fn.
+  class Server {
+    constructor(url, opts) {
+      this.url = url
+      this.opts = opts
+      this.simulateTransaction = vi.fn()
+      this.getAccount = vi.fn()
+      this.sendTransaction = vi.fn()
+      this.getTransaction = vi.fn()
+      state.servers.push(this)
+    }
+  }
+
+  // Pass the already-built transaction through unchanged so signing/parsing
+  // below exercises real XDR instead of fabricated strings.
+  function assembleTransaction(rawTx) {
+    return { build: () => rawTx }
+  }
+
+  return {
+    ...actual,
+    rpc: { ...actual.rpc, Server, assembleTransaction },
+  }
+})
+
+import {
+  Keypair,
+  Account,
+  nativeToScVal,
+} from '@stellar/stellar-sdk'
+import {
+  createRequest,
+  resolveRequest,
+  getRequestCount,
+} from '../src/lib/contract.js'
+
+const TX_HASH = 'abc123hash'
+
+// Valid G... address generated with the real SDK (needed for address-typed
+// contract arguments).
+const REQUESTER = Keypair.random().publicKey()
+
+function makeWallet() {
+  return {
+    // Pretend-signed echo: sendWrite re-parses the returned XDR as a
+    // Transaction, so echoing the unsigned envelope keeps that parse real.
+    signTransaction: vi.fn(async (xdr) => xdr),
+  }
+}
+
+function mockSuccessfulSubmit({ returnValue } = {}) {
+  const server = state.servers.at(-1)
+  server.getAccount.mockResolvedValue(new Account(REQUESTER, '100'))
+  server.simulateTransaction.mockResolvedValue({})
+  server.sendTransaction.mockResolvedValue({ status: 'PENDING', hash: TX_HASH })
+  server.getTransaction.mockResolvedValue({
+    status: 'SUCCESS',
+    hash: TX_HASH,
+    ...(returnValue !== undefined ? { returnValue } : {}),
+  })
+  return server
+}
+
+describe('contract.js — transaction submission and resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('createRequest builds, simulates, signs and confirms an emergency request', async () => {
+    const server = mockSuccessfulSubmit({
+      returnValue: nativeToScVal(7n, { type: 'u64' }),
+    })
+
+    const wallet = makeWallet()
+    const result = await createRequest(
+      REQUESTER, 52.52, 13.405, 'fire', 'nick', 'contact', wallet
+    )
+
+    expect(result).toEqual({ requestId: 7, hash: TX_HASH })
+    expect(wallet.signTransaction).toHaveBeenCalledTimes(1)
+
+    // Transaction building: one invoke_contract_function operation was simulated.
+    const tx = server.simulateTransaction.mock.calls[0][0]
+    expect(tx.operations).toHaveLength(1)
+    expect(tx.operations[0].type).toBe('invoke_contract_function')
+
+    expect(server.sendTransaction).toHaveBeenCalledTimes(1)
+    expect(server.getTransaction).toHaveBeenCalledWith(TX_HASH)
+  })
+
+  it('resolveRequest submits and confirms resolution of an emergency', async () => {
+    const server = mockSuccessfulSubmit()
+
+    await expect(
+      resolveRequest(REQUESTER, 42, makeWallet())
+    ).resolves.toBeUndefined()
+
+    expect(server.simulateTransaction).toHaveBeenCalledTimes(1)
+    expect(server.sendTransaction).toHaveBeenCalledTimes(1)
+    expect(server.getTransaction).toHaveBeenCalledWith(TX_HASH)
+  })
+
+  it('maps simulation contract errors to friendly messages without retrying', async () => {
+    const server = state.servers.at(-1)
+    server.getAccount.mockResolvedValue(new Account(REQUESTER, '100'))
+    server.simulateTransaction.mockResolvedValue({
+      error: 'Error(Contract, #2)',
+    })
+
+    const err = await createRequest(
+      REQUESTER, 52.52, 13.405, 'fire', 'nick', 'contact', makeWallet()
+    ).catch((e) => e)
+
+    expect(err.message).toBe('This wallet is not authorized for that action.')
+    expect(err.contractCode).toBe(2)
+    // Contract logic errors are deterministic — never retried.
+    expect(server.simulateTransaction).toHaveBeenCalledTimes(1)
+    expect(server.sendTransaction).not.toHaveBeenCalled()
+  })
+
+  it('surfaces friendly errors for failed emergency resolution', async () => {
+    const server = state.servers.at(-1)
+    server.getAccount.mockResolvedValue(new Account(REQUESTER, '100'))
+    server.simulateTransaction.mockResolvedValue({
+      error: 'Error(Contract, #2)',
+    })
+
+    const err = await resolveRequest(REQUESTER, 42, makeWallet()).catch((e) => e)
+
+    expect(err.message).toBe('Only the requester can resolve this request.')
+    expect(err.contractCode).toBe(2)
+  })
+
+  it('retries transient RPC failures and succeeds on a later attempt', async () => {
+    vi.useFakeTimers()
+    const server = state.servers.at(-1)
+    server.simulateTransaction
+      .mockRejectedValueOnce(new Error('Failed to fetch'))
+      .mockRejectedValueOnce(new Error('503 Service Unavailable'))
+      .mockResolvedValueOnce({
+        result: { retval: nativeToScVal(42n, { type: 'u64' }) },
+      })
+
+    const pending = getRequestCount()
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(2000)
+
+    await expect(pending).resolves.toBe(42)
+    expect(server.simulateTransaction).toHaveBeenCalledTimes(3)
+  })
+
+  it('gives up after three attempts when the RPC stays unreachable', async () => {
+    vi.useFakeTimers()
+    const server = state.servers.at(-1)
+    server.simulateTransaction.mockRejectedValue(new Error('Failed to fetch'))
+
+    const pending = expect(getRequestCount()).rejects.toThrow(
+      'Reading from contract failed after 3 attempts due to network congestion'
+    )
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(2000)
+    await pending
+    expect(server.simulateTransaction).toHaveBeenCalledTimes(3)
+  })
+
+  it('throws when the submitted transaction ends in ERROR status', async () => {
+    const server = state.servers.at(-1)
+    server.getAccount.mockResolvedValue(new Account(REQUESTER, '100'))
+    server.simulateTransaction.mockResolvedValue({})
+    server.sendTransaction.mockResolvedValue({
+      status: 'ERROR',
+      errorResult: { result: { code: -1 } },
+    })
+
+    await expect(
+      resolveRequest(REQUESTER, 42, makeWallet())
+    ).rejects.toThrow('-1')
+    expect(server.getTransaction).not.toHaveBeenCalled()
+  })
+
+  it('throws when the polled transaction fails on-chain', async () => {
+    const server = state.servers.at(-1)
+    server.getAccount.mockResolvedValue(new Account(REQUESTER, '100'))
+    server.simulateTransaction.mockResolvedValue({})
+    server.sendTransaction.mockResolvedValue({
+      status: 'PENDING',
+      hash: TX_HASH,
+    })
+    server.getTransaction.mockResolvedValue({ status: 'FAILED' })
+
+    await expect(
+      resolveRequest(REQUESTER, 42, makeWallet())
+    ).rejects.toThrow('Transaction failed')
+  })
+
+  it('times out when the transaction never confirms', async () => {
+    vi.useFakeTimers()
+    const server = state.servers.at(-1)
+    server.getAccount.mockResolvedValue(new Account(REQUESTER, '100'))
+    server.simulateTransaction.mockResolvedValue({})
+    server.sendTransaction.mockResolvedValue({
+      status: 'PENDING',
+      hash: TX_HASH,
+    })
+    server.getTransaction.mockResolvedValue({ status: 'PENDING' })
+
+    const pending = expect(
+      resolveRequest(REQUESTER, 42, makeWallet())
+    ).rejects.toThrow('Transaction timed out')
+    for (let i = 0; i < 31; i++) {
+      await vi.advanceTimersByTimeAsync(1000)
+    }
+    await pending
+  })
+})

--- a/test/document-title.test.jsx
+++ b/test/document-title.test.jsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import useDocumentTitle, { setPageTitle } from '../src/lib/useDocumentTitle'
+
+// ---------------------------------------------------------------------------
+// Issue #105 — dynamic page titles. The routed pages (Landing /help,
+// /ranking) call useDocumentTitle so document.title reflects the current
+// page during client-side navigation instead of staying "HelPhone".
+// ---------------------------------------------------------------------------
+
+function Page({ title }) {
+  useDocumentTitle(title)
+  return null
+}
+
+afterEach(() => {
+  document.title = ''
+})
+
+describe('setPageTitle', () => {
+  it('suffixes the app name', () => {
+    setPageTitle('Help')
+    expect(document.title).toBe('Help | HelPhone')
+  })
+
+  it('falls back to the app name for empty titles', () => {
+    setPageTitle('')
+    expect(document.title).toBe('HelPhone')
+  })
+})
+
+describe('useDocumentTitle', () => {
+  it('sets a unique title per page with the HelPhone suffix', () => {
+    const { unmount } = render(<Page title="Landing" />)
+    expect(document.title).toBe('Landing | HelPhone')
+    unmount()
+
+    render(<Page title="Help" />)
+    expect(document.title).not.toBe('Landing | HelPhone')
+    expect(document.title).toBe('Help | HelPhone')
+  })
+
+  it('updates on re-render when the title changes', () => {
+    const { rerender } = render(<Page title="Help" />)
+    rerender(<Page title="Ranking" />)
+    expect(document.title).toBe('Ranking | HelPhone')
+  })
+})

--- a/test/sanity.test.jsx
+++ b/test/sanity.test.jsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+// ---------------------------------------------------------------------------
+// Issue #106 — sanity test for the Vitest + jsdom + React Testing Library
+// setup. If this suite passes, the runner, DOM environment, and component
+// rendering pipeline are all wired correctly.
+// ---------------------------------------------------------------------------
+
+function SanityComponent() {
+  return <h1>HelPhone test harness</h1>
+}
+
+describe('test framework sanity', () => {
+  it('runs inside a jsdom environment', () => {
+    expect(typeof window).toBe('object')
+    expect(typeof document).toBe('object')
+  })
+
+  it('renders a React component with Testing Library matchers', () => {
+    render(<SanityComponent />)
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'HelPhone test harness'
+    )
+  })
+})

--- a/test/zk-encoding.test.js
+++ b/test/zk-encoding.test.js
@@ -1,0 +1,423 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Keypair } from '@stellar/stellar-sdk'
+
+// ---------------------------------------------------------------------------
+// Issue #108 — unit tests for src/lib/zk.js.
+//
+// Covers:
+//   - normalizeBase64 edge cases (via its exported wrappers
+//     decodeBase64Utf8 / decodeBase64Bytes)
+//   - coordinate scaling / zone building for the Noir circuits
+//   - the proof generation flow with a mocked UltraHonk backend
+//     (browser fallback) and a mocked prover server (server flow)
+// ---------------------------------------------------------------------------
+
+const bbState = vi.hoisted(() => ({
+  backends: [],
+  noirs: [],
+}))
+
+vi.mock('@aztec/bb.js', () => ({
+  UltraHonkBackend: class {
+    constructor(bytecode, options, config) {
+      this.bytecode = bytecode
+      this.options = options
+      this.config = config
+      this.instantiate = vi.fn(async () => {})
+      this.generateProof = vi.fn(async () => ({
+        proof: new Uint8Array([0xde, 0xad]),
+        publicInputs: ['1'],
+      }))
+      this.destroy = vi.fn(async () => {})
+      bbState.backends.push(this)
+    }
+  },
+}))
+
+vi.mock('@noir-lang/noir_js', () => ({
+  Noir: class {
+    constructor(artifact) {
+      this.artifact = artifact
+      this.execute = vi.fn(async () => ({
+        witness: new Uint8Array([7]),
+        returnValue: '424242',
+      }))
+      bbState.noirs.push(this)
+    }
+  },
+}))
+
+import {
+  decodeBase64Bytes,
+  decodeBase64Utf8,
+  buildLocationProofZone,
+  shortProofId,
+  generateLocationProof,
+} from '../src/lib/zk.js'
+
+const RECIPIENT = Keypair.random().publicKey()
+
+function okJson(body) {
+  return { ok: true, json: async () => body }
+}
+
+function lastFieldAsBigInt(bytes, index = 6) {
+  let value = 0n
+  for (let j = 0; j < 32; j++) {
+    value = (value << 8n) | BigInt(bytes[index * 32 + j])
+  }
+  return value
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+})
+
+describe('zk.js — Base64 normalization', () => {
+  it('decodes standard Base64', () => {
+    expect(decodeBase64Utf8('aGVsbG8=')).toBe('hello')
+  })
+
+  it('strips data URI prefixes before decoding', () => {
+    expect(decodeBase64Utf8('data:text/plain;base64,aGVsbG8=')).toBe('hello')
+  })
+
+  it('removes embedded whitespace and newlines', () => {
+    expect(decodeBase64Utf8('aGVs\nbG8\t= ')).toBe('hello')
+  })
+
+  it('pads unpadded input', () => {
+    expect(decodeBase64Utf8('aGVsbG8')).toBe('hello')
+    expect(decodeBase64Utf8('aGVsbG')).toBe('hell')
+  })
+
+  it('converts URL-safe - and _ characters back to + and /', () => {
+    expect(Array.from(decodeBase64Bytes('----'))).toEqual([251, 239, 190])
+    expect(Array.from(decodeBase64Bytes('_--_'))).toEqual([255, 239, 190])
+  })
+
+  it('accepts an empty string as empty bytes', () => {
+    expect(decodeBase64Bytes('')).toHaveLength(0)
+  })
+
+  it('rejects invalid Base64 characters', () => {
+    expect(() => decodeBase64Utf8('not base64!')).toThrow(
+      'contains invalid Base64 characters'
+    )
+    // Padding longer than two '=' characters is malformed too.
+    expect(() => decodeBase64Utf8('aGVsbG8===')).toThrow(
+      'contains invalid Base64 characters'
+    )
+  })
+
+  it('rejects impossible lengths (length % 4 === 1)', () => {
+    expect(() => decodeBase64Utf8('abcde')).toThrow(
+      'has an invalid Base64 length'
+    )
+  })
+
+  it('rejects non-string input and includes the label in errors', () => {
+    expect(() => decodeBase64Utf8(123)).toThrow('must be a string')
+    expect(() => decodeBase64Bytes(null)).toThrow('must be a string')
+    expect(() => decodeBase64Utf8('###', 'Proof blob')).toThrow(
+      'Proof blob contains invalid Base64 characters.'
+    )
+  })
+})
+
+describe('zk.js — location proof zone encoding', () => {
+  it('throws for missing or non-finite coordinates', () => {
+    expect(() => buildLocationProofZone({})).toThrow(
+      'A valid location is required to build a ZK proof zone'
+    )
+    expect(() =>
+      buildLocationProofZone({ lat: Number.NaN, lng: 0 })
+    ).toThrow('A valid location is required to build a ZK proof zone')
+    expect(() =>
+      buildLocationProofZone({ lat: 0, lng: Number.POSITIVE_INFINITY })
+    ).toThrow('A valid location is required to build a ZK proof zone')
+  })
+
+  it('scales coordinates into the fixed-point box around the center', () => {
+    const lat = 52.52
+    const lng = 13.405
+    const radiusMeters = 3000
+    const zone = buildLocationProofZone({ lat, lng, radiusMeters })
+
+    // Independent re-derivation of the documented encoding:
+    //   stored_lng = floor(lng * 1e7) + 1_800_000_000
+    //   stored_lat = floor(lat * 1e7) +   900_000_000
+    const latDelta = radiusMeters / 111320
+    const lngScale = Math.max(0.2, Math.cos((lat * Math.PI) / 180))
+    const lngDelta = radiusMeters / (111320 * lngScale)
+    const encodeLngNumber = (v) => Math.floor(v * 1e7) + 1_800_000_000
+    const encodeLatNumber = (v) => Math.floor(v * 1e7) + 900_000_000
+
+    expect(zone.radiusMeters).toBe(radiusMeters)
+    expect(zone.center).toEqual({ lat, lng })
+    expect(zone.boxXMin).toBe(String(encodeLngNumber(lng - lngDelta)))
+    expect(zone.boxXMax).toBe(String(encodeLngNumber(lng + lngDelta)))
+    expect(zone.boxYMin).toBe(String(encodeLatNumber(lat - latDelta)))
+    expect(zone.boxYMax).toBe(String(encodeLatNumber(lat + latDelta)))
+    expect(Number(zone.boxXMin)).toBeLessThan(Number(zone.boxXMax))
+    expect(Number(zone.boxYMin)).toBeLessThan(Number(zone.boxYMax))
+  })
+
+  it('clamps the radius to the supported range and defaults sanely', () => {
+    expect(buildLocationProofZone({ lat: 0, lng: 0, radiusMeters: 1 }).radiusMeters).toBe(250)
+    expect(
+      buildLocationProofZone({ lat: 0, lng: 0, radiusMeters: 99_999 }).radiusMeters
+    ).toBe(25_000)
+    expect(buildLocationProofZone({ lat: 0, lng: 0 }).radiusMeters).toBe(3000)
+    expect(
+      buildLocationProofZone({ lat: 0, lng: 0, radiusMeters: Number.NaN }).radiusMeters
+    ).toBe(3000)
+  })
+
+  it('clamps encoded boxes to the circuit field bounds at extreme coordinates', () => {
+    expect(buildLocationProofZone({ lat: 90, lng: 180 })).toMatchObject({
+      boxXMax: '3600000000',
+      boxYMax: '1800000000',
+    })
+    expect(buildLocationProofZone({ lat: -90, lng: -180 })).toMatchObject({
+      boxXMin: '0',
+      boxYMin: '0',
+    })
+  })
+})
+
+describe('zk.js — shortProofId', () => {
+  it('returns short values unchanged and truncates long ones', () => {
+    expect(shortProofId('short')).toBe('short')
+    expect(shortProofId('')).toBe('')
+    expect(shortProofId(null)).toBe('')
+    const long = 'abcdefghij1234567890abcdef'
+    expect(shortProofId(long)).toBe('abcdefghij...abcdef')
+  })
+})
+
+describe('zk.js — server proof generation flow', () => {
+  it('requests a proof from the prover server and packs public inputs', async () => {
+    const proveBodies = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url, opts = {}) => {
+        const u = String(url)
+        if (u.includes('/health')) return okJson({ ready: true })
+        proveBodies.push(JSON.parse(opts.body))
+        return okJson({
+          success: true,
+          proof: '0x00ff10',
+          nullifier: '999',
+        })
+      })
+    )
+
+    const zone = buildLocationProofZone({ lat: 48.85, lng: 2.35 })
+    const result = await generateLocationProof({
+      lat: 48.85,
+      lng: 2.35,
+      campaignId: '7',
+      recipientAddress: RECIPIENT,
+      zone,
+      onLog: () => {},
+    })
+
+    expect(Array.from(result.proof)).toEqual([0x00, 0xff, 0x10])
+    expect(result.nullifier).toBe('999')
+    expect(result.publicInputsBytes).toHaveLength(224)
+    expect(result.publicInputsPrefix).toHaveLength(160)
+
+    // Public inputs layout: box_x_min | ... | campaign_id | recipient | nullifier
+    expect(lastFieldAsBigInt(result.publicInputsBytes, 6)).toBe(999n)
+    expect(proveBodies).toHaveLength(1)
+
+    const inputs = proveBodies[0].inputs
+    expect(inputs.user_x).toBe(String(Math.floor(2.35 * 1e7) + 1_800_000_000))
+    expect(inputs.user_y).toBe(String(Math.floor(48.85 * 1e7) + 900_000_000))
+    expect(inputs.box_x_min).toBe(zone.boxXMin)
+    expect(inputs.box_x_max).toBe(zone.boxXMax)
+    expect(inputs.box_y_min).toBe(zone.boxYMin)
+    expect(inputs.box_y_max).toBe(zone.boxYMax)
+    expect(inputs.campaign_id).toBe('7')
+    expect(inputs.recipient_address).toMatch(/^\d+$/)
+  })
+
+  it('propagates the server error message when proving fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url) =>
+        String(url).includes('/health')
+          ? okJson({ ready: true })
+          : { ok: false, json: async () => ({ error: 'circuit rejected' }) }
+      )
+    )
+
+    const zone = buildLocationProofZone({ lat: 1, lng: 2 })
+    await expect(
+      generateLocationProof({
+        lat: 1,
+        lng: 2,
+        recipientAddress: RECIPIENT,
+        zone,
+        onLog: () => {},
+      })
+    ).rejects.toThrow(/circuit rejected/)
+  })
+
+  it('surfaces failures when the server responds with success=false', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url) =>
+        String(url).includes('/health')
+          ? okJson({ ready: true })
+          : okJson({ success: false, error: 'witness failed' })
+      )
+    )
+
+    const zone = buildLocationProofZone({ lat: 1, lng: 2 })
+    await expect(
+      generateLocationProof({
+        lat: 1,
+        lng: 2,
+        recipientAddress: RECIPIENT,
+        zone,
+        onLog: () => {},
+      })
+    ).rejects.toThrow(/witness failed/)
+  })
+
+  it('reports an unreachable prover instead of hanging', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch')
+      })
+    )
+
+    const zone = buildLocationProofZone({ lat: 1, lng: 2 })
+    await expect(
+      generateLocationProof({
+        lat: 1,
+        lng: 2,
+        recipientAddress: RECIPIENT,
+        zone,
+        onLog: () => {},
+      })
+    ).rejects.toThrow('ZK prover server is unreachable')
+  })
+})
+
+describe('zk.js — browser proof generation with mocked UltraHonk backend', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('falls back to browser proving when the server is unavailable', async () => {
+    vi.stubEnv('VITE_ZK_BROWSER_FALLBACK', 'true')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch')
+      })
+    )
+
+    const zone = buildLocationProofZone({ lat: 52.52, lng: 13.405 })
+    const logs = []
+    const result = await generateLocationProof({
+      lat: 52.52,
+      lng: 13.405,
+      campaignId: '7',
+      recipientAddress: RECIPIENT,
+      zone,
+      onLog: (msg) => logs.push(msg),
+    })
+
+    // UltraHonk backend was constructed from the circuit artifact and used
+    // for instantiation + proof generation.
+    const backend = bbState.backends.at(-1)
+    expect(typeof backend.bytecode).toBe('string')
+    expect(backend.bytecode.length).toBeGreaterThan(0)
+    expect(backend.config).toEqual({ recursive: false })
+    expect(backend.instantiate).toHaveBeenCalledTimes(1)
+    expect(backend.generateProof).toHaveBeenCalledTimes(1)
+    const witness = backend.generateProof.mock.calls[0][0]
+    expect(Array.from(witness)).toEqual([7])
+
+    // Noir circuit executed with the scaled/encoded inputs.
+    const noir = bbState.noirs.at(-1)
+    const inputs = noir.execute.mock.calls[0][0]
+    expect(inputs.user_x).toBe(String(Math.floor(13.405 * 1e7) + 1_800_000_000))
+    expect(inputs.user_y).toBe(String(Math.floor(52.52 * 1e7) + 900_000_000))
+    expect(inputs.box_x_min).toBe(zone.boxXMin)
+    expect(inputs.box_x_max).toBe(zone.boxXMax)
+    expect(inputs.box_y_min).toBe(zone.boxYMin)
+    expect(inputs.box_y_max).toBe(zone.boxYMax)
+    expect(inputs.campaign_id).toBe('7')
+
+    // Circuit return value becomes the nullifier; proof bytes pass through;
+    // public inputs are packed into seven big-endian 32-byte fields.
+    expect(result.nullifier).toBe('424242')
+    expect(Array.from(result.proof)).toEqual([0xde, 0xad])
+    expect(result.publicInputsBytes).toHaveLength(224)
+    expect(result.publicInputsPrefix).toHaveLength(160)
+    expect(lastFieldAsBigInt(result.publicInputsBytes, 6)).toBe(424242n)
+    expect(logs.some((l) => l.includes('UltraHonk'))).toBe(true)
+  })
+
+  it('reuses the persisted ZK secret between proofs', async () => {
+    vi.stubEnv('VITE_ZK_BROWSER_FALLBACK', 'true')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch')
+      })
+    )
+
+    const zone = buildLocationProofZone({ lat: 10, lng: 20 })
+    await generateLocationProof({
+      lat: 10,
+      lng: 20,
+      recipientAddress: RECIPIENT,
+      zone,
+      onLog: () => {},
+    })
+    await generateLocationProof({
+      lat: 10,
+      lng: 20,
+      recipientAddress: RECIPIENT,
+      zone,
+      onLog: () => {},
+    })
+
+    const secret = localStorage.getItem('hp_zk_secret')
+    expect(secret).toBeTruthy()
+
+    const noir = bbState.noirs.at(-1)
+    const [firstInputs, secondInputs] = noir.execute.mock.calls.slice(-2)
+    expect(firstInputs.secret_id).toBe(secret)
+    expect(secondInputs.secret_id).toBe(secret)
+  })
+
+  it('refuses to prove without a valid Stellar address', async () => {
+    vi.stubEnv('VITE_ZK_BROWSER_FALLBACK', 'true')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch')
+      })
+    )
+
+    const zone = buildLocationProofZone({ lat: 1, lng: 2 })
+    await expect(
+      generateLocationProof({
+        lat: 1,
+        lng: 2,
+        recipientAddress: 'GINVALID',
+        zone,
+        onLog: () => {},
+      })
+    ).rejects.toThrow('Connect a valid Stellar wallet before generating the proof.')
+  })
+})


### PR DESCRIPTION
## Summary

Adds the missing unit-test coverage for the contract and ZK libraries, a framework sanity test, and dynamic page titles so `document.title` reflects the current page during client-side navigation.

Note: Vitest, jsdom, React Testing Library, and the vitest config block in `vite.config.js` were already present on `main`, so issue #106's remaining gap was the sanity test confirming the setup works end-to-end.

## Changes

- **Issue #105**: New generic utility `src/lib/useDocumentTitle.js` (`setPageTitle` + `useDocumentTitle` hook) that sets `document.title` with a ` | HelPhone` suffix. Wired into the Landing (`App.jsx`), Help, and Ranking pages with unique titles; covered by `test/document-title.test.jsx`.
- **Issue #106**: Added `test/sanity.test.jsx`, a minimal suite verifying the Vitest runner, jsdom environment, and React Testing Library render pipeline work.
- **Issue #107**: Added `test/contract-functions.test.js`. The Soroban RPC client (`rpc.Server`) is mocked at the SDK boundary while transactions are built with the real `TransactionBuilder`/`Operation` code. Covers the emergency submission path (`createRequest`) and resolution path (`resolveRequest`, the actual name of the resolve-emergency flow): happy-path build/simulate/sign/submit/poll, friendly contract-error mapping without retries, transient-network retry with backoff, retry exhaustion, `ERROR` submit status, on-chain `FAILED` result, and confirmation timeout.
- **Issue #108**: Added `test/zk-encoding.test.js`. Covers `normalizeBase64` edge cases via its exported wrappers (data URIs, whitespace, URL-safe `-`/`_`, missing padding, `%4 === 1` lengths, invalid characters/labels), `buildLocationProofZone` coordinate scaling/radius clamps/circuit field bounds, `shortProofId`, the server prover flow (health check, proof request body encoding, error branches), and the browser fallback proof flow against a mocked UltraHonk backend and Noir circuit, including persisted-secret reuse.

## Issues

Resolves #105
Resolves #106
Resolves #107
Resolves #108

## Verification

Manual code review only: full diff inspected, ESLint passes on all touched files with no new findings beyond pre-existing repo-wide warnings. `cargo build` and `cargo test` were not run (no Rust changes); per review policy the JavaScript suites were not executed — verification was done by line-by-line review against the implementation.
