### PR TITLE
feat: resolved frontend issues 

### DIFF
--- a/src/components/Breadcrumb.jsx
+++ b/src/components/Breadcrumb.jsx
@@ -58,7 +58,7 @@ export default function Breadcrumb() {
 
         return (
           <span key={routeTo} style={{ display: "flex", alignItems: "center", gap: "6px" }}>
-            <span style={{ color: "rgba(242, 236, 220, 0.25)" }}>/</span>
+            <span style={{ color: "rgba(242, 236, 220, 0.72)" }}>/</span>
             {isLast ? (
               <span style={{ color: "rgba(242, 236, 220, 0.9)", fontWeight: 600 }}>
                 {label}

--- a/src/components/layout/Navbar.css
+++ b/src/components/layout/Navbar.css
@@ -80,7 +80,7 @@
 
 .hp-navbar__link--dim {
   font-size: 12px;
-  color: rgba(242, 236, 220, 0.35);
+  color: rgba(242, 236, 220, 0.72);
 }
 
 .hp-navbar__link--back {

--- a/src/components/ui/Input.css
+++ b/src/components/ui/Input.css
@@ -43,7 +43,7 @@
 }
 
 .hp-input::placeholder {
-  color: rgba(242, 236, 220, 0.35);
+  color: rgba(242, 236, 220, 0.72);
 }
 
 .hp-input:focus {
@@ -81,7 +81,7 @@
 
 .hp-input-hint {
   font-size: 11px;
-  color: rgba(242, 236, 220, 0.38);
+  color: rgba(242, 236, 220, 0.72);
 }
 
 .hp-input-hint--light {

--- a/src/components/ui/Modal.jsx
+++ b/src/components/ui/Modal.jsx
@@ -1,4 +1,5 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
 import "./Modal.css";
 
 /**
@@ -28,6 +29,9 @@ export default function Modal({
   style,
   ...props
 }) {
+  const dialogRef = useRef(null);
+  useFocusTrap(open, dialogRef);
+
   useEffect(() => {
     if (!open) return;
     function onKey(e) {
@@ -58,6 +62,8 @@ export default function Modal({
       style={overlayStyle}
     >
       <div
+        ref={dialogRef}
+        tabIndex={-1}
         className={`hp-modal ${variantClass} ${sizeClass} ${className}`}
         onClick={(e) => e.stopPropagation()}
         style={style}

--- a/src/hooks/useEscapeKey.js
+++ b/src/hooks/useEscapeKey.js
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * useEscapeKey — closes modal on Escape and restores focus to trigger element.
+ *
+ * - Adds global document-level keydown listener when active
+ * - Calls onClose when Escape is pressed
+ * - Restores focus to the element that had focus before modal opened
+ *
+ * @param {boolean} active — whether modal is open
+ * @param {() => void} onClose — close handler
+ */
+export function useEscapeKey(active, onClose) {
+  const previousFocusRef = useRef(null);
+
+  useEffect(() => {
+    if (!active) return undefined;
+    previousFocusRef.current = document.activeElement;
+
+    function handleKeyDown(e) {
+      if (e.key === "Escape" && typeof onClose === "function") {
+        e.stopPropagation();
+        onClose();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      // Restore focus to triggering element after close
+      if (previousFocusRef.current instanceof HTMLElement) {
+        // Use microtask to avoid conflict with focus trap cleanup
+        queueMicrotask(() => {
+          if (previousFocusRef.current instanceof HTMLElement) {
+            try {
+              previousFocusRef.current.focus();
+            } catch {}
+          }
+        });
+      }
+    };
+  }, [active, onClose]);
+}
+
+export default useEscapeKey;

--- a/src/hooks/useFocusTrap.js
+++ b/src/hooks/useFocusTrap.js
@@ -1,0 +1,103 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * useFocusTrap — lightweight focus trap utility (no external dependency).
+ *
+ * Traps keyboard navigation (Tab / Shift+Tab) within the container element
+ * when `active` is true. Also moves initial focus to the first interactive
+ * element inside the container on activation.
+ *
+ * Acceptance:
+ * - Apply to all modal / dialog components
+ * - Ensure initial focus is set to first interactive element
+ *
+ * @param {boolean} active — whether trap is active (modal open)
+ * @param {import('react').RefObject<HTMLElement>} containerRef — dialog element ref
+ */
+export function useFocusTrap(active, containerRef) {
+  const previousFocusRef = useRef(null);
+
+  useEffect(() => {
+    if (!active) return undefined;
+    const container = containerRef.current;
+    if (!container) return undefined;
+
+    // Store element that had focus before modal opened
+    previousFocusRef.current = document.activeElement;
+
+    const FOCUSABLE_SELECTOR =
+      'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+    const getFocusable = () => {
+      if (!container) return [];
+      const nodes = Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR));
+      // Filter out hidden/inert elements
+      return nodes.filter((el) => {
+        if (el.hasAttribute("disabled")) return false;
+        if (el.getAttribute("aria-hidden") === "true") return false;
+        // offsetParent null means hidden, but keep if it is the activeElement
+        return true;
+      });
+    };
+
+    // Focus first interactive element, fallback to container
+    const focusable = getFocusable();
+    if (focusable.length > 0) {
+      focusable[0].focus();
+    } else if (container.getAttribute("tabindex") !== null) {
+      container.focus();
+    } else {
+      container.setAttribute("tabindex", "-1");
+      container.focus();
+    }
+
+    function handleKeyDown(e) {
+      if (e.key !== "Tab") return;
+      const focusableElements = getFocusable();
+      if (focusableElements.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusableElements[0];
+      const last = focusableElements[focusableElements.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [active, containerRef]);
+}
+
+/**
+ * useFocusTrapWithRestore — variant that also restores focus to trigger on unmount/close.
+ * Used when escape handling is managed separately (issue #92). If you want combined
+ * behavior, use this hook instead of useFocusTrap + manual restore.
+ */
+export function useFocusTrapWithRestore(active, containerRef) {
+  const previousFocusRef = useRef(null);
+  useEffect(() => {
+    if (!active) return undefined;
+    previousFocusRef.current = document.activeElement;
+    return () => {
+      if (previousFocusRef.current instanceof HTMLElement) {
+        previousFocusRef.current.focus();
+      }
+    };
+  }, [active]);
+
+  useFocusTrap(active, containerRef);
+}
+
+export default useFocusTrap;

--- a/src/hooks/useFocusTrap.js
+++ b/src/hooks/useFocusTrap.js
@@ -76,6 +76,12 @@ export function useFocusTrap(active, containerRef) {
     document.addEventListener("keydown", handleKeyDown);
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
+      // Restore focus to triggering element (WCAG: focus return)
+      if (previousFocusRef.current instanceof HTMLElement) {
+        try {
+          previousFocusRef.current.focus();
+        } catch {}
+      }
     };
   }, [active, containerRef]);
 }

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -345,7 +345,7 @@ export default function Admin() {
           )}
           <p
             style={{
-              color: "rgba(242,236,220,0.35)",
+              color: "rgba(242,236,220,0.72)",
               fontSize: "12px",
               maxWidth: "380px",
               lineHeight: 1.6,
@@ -507,7 +507,7 @@ export default function Admin() {
                   style={{
                     fontSize: "9px",
                     letterSpacing: "1px",
-                    color: "rgba(242,236,220,0.35)",
+                    color: "rgba(242,236,220,0.72)",
                     marginBottom: "6px",
                   }}
                 >
@@ -538,7 +538,7 @@ export default function Admin() {
                   style={{
                     fontSize: "9px",
                     letterSpacing: "1px",
-                    color: "rgba(242,236,220,0.35)",
+                    color: "rgba(242,236,220,0.72)",
                     marginBottom: "6px",
                   }}
                 >

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -726,7 +726,7 @@ function Step({ n, title, subtitle, done, active, children }) {
             <div
               style={{
                 fontSize: "11px",
-                color: "rgba(242,236,220,0.35)",
+                color: "rgba(242,236,220,0.72)",
                 marginTop: "1px",
               }}
             >
@@ -1526,7 +1526,7 @@ function TrackingScreen({
                 style={{
                   fontSize: "9px",
                   letterSpacing: "1px",
-                  color: "rgba(242,236,220,0.32)",
+                  color: "rgba(242,236,220,0.70)",
                   marginBottom: "4px",
                 }}
               >
@@ -1558,7 +1558,7 @@ function TrackingScreen({
                 style={{
                   fontSize: "9px",
                   letterSpacing: "1px",
-                  color: "rgba(242,236,220,0.32)",
+                  color: "rgba(242,236,220,0.70)",
                   marginBottom: "4px",
                 }}
               >
@@ -1580,7 +1580,7 @@ function TrackingScreen({
                 style={{
                   fontSize: "9px",
                   letterSpacing: "1px",
-                  color: "rgba(242,236,220,0.32)",
+                  color: "rgba(242,236,220,0.70)",
                   marginBottom: "4px",
                 }}
               >
@@ -1602,7 +1602,7 @@ function TrackingScreen({
                 style={{
                   fontSize: "9px",
                   letterSpacing: "1px",
-                  color: "rgba(242,236,220,0.32)",
+                  color: "rgba(242,236,220,0.70)",
                   marginBottom: "4px",
                 }}
               >
@@ -1781,7 +1781,7 @@ function FilteredRequestList({
 
   if (filtered.length === 0) {
     return (
-      <p style={{ fontSize: "12px", color: "rgba(242,236,220,0.3)" }}>
+      <p style={{ fontSize: "12px", color: "rgba(242,236,220,0.70)" }}>
         No requests match this filter.
       </p>
     );
@@ -1795,7 +1795,7 @@ function FilteredRequestList({
           Pending: { color: "#a2a586", bg: "rgba(162,165,134,0.15)" },
           Enroute: { color: "#7357FF", bg: "rgba(115,87,255,0.15)" },
           Resolved: { color: "#3F8487", bg: "rgba(63,132,135,0.15)" },
-          Cancelled: { color: "rgba(242,236,220,0.3)", bg: "rgba(255,255,255,0.04)" },
+          Cancelled: { color: "rgba(242,236,220,0.70)", bg: "rgba(255,255,255,0.04)" },
         };
         const sc = statusColors[req.status] || statusColors.Cancelled;
         const et = EMERGENCY_TYPES.find((e) => e.id === req.emergency_type);
@@ -1844,10 +1844,10 @@ function FilteredRequestList({
                     {req.status?.toUpperCase()}
                   </span>
                 </div>
-                <div style={{ fontSize: "10px", color: "rgba(242,236,220,0.35)", marginTop: "3px", lineHeight: 1.4 }}>
+                <div style={{ fontSize: "10px", color: "rgba(242,236,220,0.72)", marginTop: "3px", lineHeight: 1.4 }}>
                   {et ? `${et.icon} ${et.label}` : req.emergency_type || "Unknown"}
                   {timeAgo && (
-                    <span style={{ marginLeft: "6px", color: "rgba(242,236,220,0.2)" }}>· {timeAgo}</span>
+                    <span style={{ marginLeft: "6px", color: "rgba(242,236,220,0.65)" }}>· {timeAgo}</span>
                   )}
                 </div>
               </div>
@@ -3728,7 +3728,7 @@ export default function Help() {
               to="/"
               style={{
                 fontSize: "12px",
-                color: "rgba(242,236,220,0.35)",
+                color: "rgba(242,236,220,0.72)",
                 textDecoration: "none",
                 minHeight: "44px",
                 display: "flex",
@@ -3840,7 +3840,7 @@ export default function Help() {
                     zkStatus === "error"
                       ? "#FF7A6B"
                       : zkStatus === "idle"
-                        ? "rgba(242,236,220,0.28)"
+                        ? "rgba(242,236,220,0.68)"
                         : "rgba(179,166,255,0.2)",
                   position: "relative",
                   overflow: "hidden",
@@ -3939,7 +3939,7 @@ export default function Help() {
                     style={{
                       fontSize: "8px",
                       letterSpacing: "0.9px",
-                      color: "rgba(242,236,220,0.28)",
+                      color: "rgba(242,236,220,0.68)",
                       marginBottom: "3px",
                     }}
                   >
@@ -3969,7 +3969,7 @@ export default function Help() {
                     style={{
                       fontSize: "8px",
                       letterSpacing: "0.9px",
-                      color: "rgba(242,236,220,0.28)",
+                      color: "rgba(242,236,220,0.68)",
                       marginBottom: "3px",
                     }}
                   >
@@ -4024,7 +4024,7 @@ export default function Help() {
                     key={`${line}-${i}`}
                     style={{
                       fontSize: "9.5px",
-                      color: "rgba(242,236,220,0.34)",
+                      color: "rgba(242,236,220,0.70)",
                       lineHeight: 1.35,
                     }}
                   >
@@ -4257,7 +4257,7 @@ export default function Help() {
                             marginLeft: "auto",
                             background: "none",
                             border: "none",
-                            color: "rgba(242,236,220,0.35)",
+                            color: "rgba(242,236,220,0.72)",
                             fontSize: "11px",
                             cursor: "pointer",
                             padding: 0,
@@ -4341,7 +4341,7 @@ export default function Help() {
                                 style={{
                                   padding: "10px 12px",
                                   fontSize: "11px",
-                                  color: "rgba(242,236,220,0.35)",
+                                  color: "rgba(242,236,220,0.72)",
                                 }}
                               >
                                 Searching references...
@@ -4382,7 +4382,7 @@ export default function Help() {
                                 <div
                                   style={{
                                     fontSize: "10px",
-                                    color: "rgba(242,236,220,0.34)",
+                                    color: "rgba(242,236,220,0.70)",
                                     marginTop: "2px",
                                   }}
                                 >
@@ -4399,7 +4399,7 @@ export default function Help() {
                       <p
                         style={{
                           fontSize: "11px",
-                          color: "rgba(242,236,220,0.3)",
+                          color: "rgba(242,236,220,0.70)",
                           margin: "6px 0 0",
                         }}
                       >
@@ -4483,7 +4483,7 @@ export default function Help() {
                           style={{
                             background: "none",
                             border: "none",
-                            color: "rgba(242,236,220,0.35)",
+                            color: "rgba(242,236,220,0.72)",
                             fontSize: "12px",
                             cursor: "pointer",
                             display: "flex",
@@ -4696,7 +4696,7 @@ export default function Help() {
                     <p
                       style={{
                         fontSize: "11px",
-                        color: "rgba(242,236,220,0.35)",
+                        color: "rgba(242,236,220,0.72)",
                         margin: "0 0 10px",
                         lineHeight: 1.5,
                       }}
@@ -4717,7 +4717,7 @@ export default function Help() {
                         color:
                           step1Done && step2Done && isWalletConnected
                             ? "#fff"
-                            : "rgba(242,236,220,0.25)",
+                            : "rgba(242,236,220,0.72)",
                         border: "none",
                         borderRadius: "10px",
                         fontSize: "15px",
@@ -4951,7 +4951,7 @@ export default function Help() {
                         marginLeft: "auto",
                         background: "none",
                         border: "none",
-                        color: "rgba(242,236,220,0.35)",
+                        color: "rgba(242,236,220,0.72)",
                         fontSize: "18px",
                         cursor: "pointer",
                       }}
@@ -4972,7 +4972,7 @@ export default function Help() {
                           : "rgba(255,255,255,0.08)",
                         color: isWalletConnected
                           ? "#fff"
-                          : "rgba(242,236,220,0.25)",
+                          : "rgba(242,236,220,0.72)",
                         border: "none",
                         borderRadius: "10px",
                         fontSize: "15px",
@@ -5009,7 +5009,7 @@ export default function Help() {
                       alignItems: "center",
                       gap: "6px",
                       marginTop: "8px",
-                      color: "rgba(242,236,220,0.34)",
+                      color: "rgba(242,236,220,0.70)",
                       fontSize: "11px",
                       lineHeight: 1.45,
                     }}
@@ -5107,7 +5107,7 @@ export default function Help() {
                     <p
                       style={{
                         fontSize: "12px",
-                        color: "rgba(242,236,220,0.3)",
+                        color: "rgba(242,236,220,0.70)",
                         lineHeight: 1.5,
                       }}
                     >
@@ -5181,7 +5181,7 @@ export default function Help() {
                               <div
                                 style={{
                                   fontSize: "10px",
-                                  color: "rgba(242,236,220,0.3)",
+                                  color: "rgba(242,236,220,0.70)",
                                   marginTop: "1px",
                                 }}
                               >
@@ -5223,7 +5223,7 @@ export default function Help() {
                 >
                   MY REQUESTS{" "}
                   {myRequests.length > 0 && (
-                    <span style={{ color: "rgba(242,236,220,0.3)" }}>
+                    <span style={{ color: "rgba(242,236,220,0.70)" }}>
                       ({myRequests.length})
                     </span>
                   )}
@@ -5255,7 +5255,7 @@ export default function Help() {
                         borderRadius: "6px",
                         border: "none",
                         background: historyFilter === key ? "rgba(63,132,135,0.25)" : "transparent",
-                        color: historyFilter === key ? "#3F8487" : "rgba(242,236,220,0.35)",
+                        color: historyFilter === key ? "#3F8487" : "rgba(242,236,220,0.72)",
                         fontSize: "10px",
                         fontWeight: 600,
                         cursor: "pointer",
@@ -5332,7 +5332,7 @@ export default function Help() {
                   </div>
                 ) : myRequests.length === 0 ? (
                   <p
-                    style={{ fontSize: "12px", color: "rgba(242,236,220,0.3)" }}
+                    style={{ fontSize: "12px", color: "rgba(242,236,220,0.70)" }}
                   >
                     You haven&apos;t requested help yet.
                   </p>
@@ -5361,7 +5361,7 @@ export default function Help() {
                         bg: "rgba(63,132,135,0.15)",
                       },
                       Cancelled: {
-                        color: "rgba(242,236,220,0.3)",
+                        color: "rgba(242,236,220,0.70)",
                         bg: "rgba(255,255,255,0.04)",
                       },
                     };
@@ -5475,7 +5475,7 @@ export default function Help() {
                             <div
                               style={{
                                 fontSize: "10px",
-                                color: "rgba(242,236,220,0.35)",
+                                color: "rgba(242,236,220,0.72)",
                                 marginTop: "3px",
                                 lineHeight: 1.4,
                               }}
@@ -5487,7 +5487,7 @@ export default function Help() {
                                 <span
                                   style={{
                                     marginLeft: "6px",
-                                    color: "rgba(242,236,220,0.2)",
+                                    color: "rgba(242,236,220,0.65)",
                                   }}
                                 >
                                   · {timeAgo}
@@ -5889,7 +5889,7 @@ export default function Help() {
                   <div
                     style={{
                       fontSize: "11px",
-                      color: "rgba(242,236,220,0.35)",
+                      color: "rgba(242,236,220,0.72)",
                       lineHeight: 1.4,
                     }}
                   >
@@ -6078,7 +6078,7 @@ export default function Help() {
                     <div
                       style={{
                         fontSize: "11px",
-                        color: "rgba(242,236,220,0.35)",
+                        color: "rgba(242,236,220,0.72)",
                         marginTop: "2px",
                         overflow: "hidden",
                         textOverflow: "ellipsis",
@@ -6100,7 +6100,7 @@ export default function Help() {
                         style={{
                           fontSize: "10px",
                           letterSpacing: "1.4px",
-                          color: "rgba(242,236,220,0.32)",
+                          color: "rgba(242,236,220,0.70)",
                           marginBottom: "6px",
                         }}
                       >
@@ -6133,7 +6133,7 @@ export default function Help() {
                       background: "rgba(255,255,255,0.06)",
                       border: "1px solid rgba(255,255,255,0.08)",
                       borderRadius: "8px",
-                      color: "rgba(242,236,220,0.35)",
+                      color: "rgba(242,236,220,0.72)",
                       fontSize: "13px",
                       cursor: "pointer",
                       padding: "6px 8px",
@@ -6179,7 +6179,7 @@ export default function Help() {
                         <div
                           style={{
                             fontSize: "9.5px",
-                            color: "rgba(242,236,220,0.3)",
+                            color: "rgba(242,236,220,0.70)",
                             marginTop: "2px",
                           }}
                         >
@@ -7107,7 +7107,7 @@ export default function Help() {
                       <div
                         style={{
                           fontSize: "12px",
-                          color: "rgba(242,236,220,0.35)",
+                          color: "rgba(242,236,220,0.72)",
                           lineHeight: 1.3,
                         }}
                       >

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -19,6 +19,7 @@ import { useWalletState } from "../hooks/useWalletState";
 import { useClusterer } from "../hooks/useClusterer";
 import { useGeofencing } from "../hooks/useGeofencing";
 import { useFocusTrap } from "../hooks/useFocusTrap";
+import { useEscapeKey } from "../hooks/useEscapeKey";
 import {
   getRequest,
   getActiveRequests,
@@ -479,6 +480,7 @@ function sanitizeTxHash(txHash) {
 function ArrivalThanksModal({ open, onClose, requestLabel, txHash }) {
   const dialogRef = useRef(null);
   useFocusTrap(open, dialogRef);
+  useEscapeKey(open, onClose);
   if (!open) return null;
 
   const handleLastAction = (e) => {
@@ -2424,6 +2426,7 @@ const ALL_CHARS = [
 function AvatarSelectionModal({ open, onClose, selected, onSelect }) {
   const dialogRef = useRef(null);
   useFocusTrap(open, dialogRef);
+  useEscapeKey(open, onClose);
   if (!open) return null;
 
   return (
@@ -2723,6 +2726,10 @@ export default function Help() {
   useFocusTrap(showDisconnectConfirm, disconnectDialogRef);
   useFocusTrap(showResolveConfirm, resolveDialogRef);
   useFocusTrap(showEmergencyModal, emergencyDialogRef);
+  useEscapeKey(showCancelConfirm !== null, () => setShowCancelConfirm(null));
+  useEscapeKey(showDisconnectConfirm, () => setShowDisconnectConfirm(false));
+  useEscapeKey(showResolveConfirm, () => setShowResolveConfirm(false));
+  useEscapeKey(showEmergencyModal, () => setShowEmergencyModal(false));
   const handleOfferBusy = useRef(false);
   const handleOfferMounted = useRef(true);
   const handleOfferSeq = useRef(0);

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -882,11 +882,16 @@ export function FeedbackModal({ open, onClose, onSubmit }) {
                 </button>
               ))}
             </div>
+            <label htmlFor="hp-feedback-comment" className="hp-sr-only">
+              Additional feedback comment
+            </label>
             <textarea
+              id="hp-feedback-comment"
               value={comment}
               onChange={(e) => setComment(e.target.value)}
               maxLength={500}
               placeholder="Optional comment…"
+              aria-label="Additional feedback comment"
               rows={3}
               style={{
                 width: "100%",
@@ -4271,7 +4276,11 @@ export default function Help() {
                         position: "relative",
                       }}
                     >
+                      <label htmlFor="hp-search-location" className="hp-sr-only">
+                        Search city or country
+                      </label>
                       <input
+                        id="hp-search-location"
                         style={S.input}
                         placeholder="Or search city, country…"
                         value={searchQuery}
@@ -4510,7 +4519,11 @@ export default function Help() {
                       marginTop: "4px",
                     }}
                   >
+                    <label htmlFor="hp-nickname" style={{ fontSize: "10px", fontWeight: 600, letterSpacing: "0.8px", textTransform: "uppercase", color: "rgba(242,236,220,0.72)" }}>
+                      Nickname or name
+                    </label>
                     <input
+                      id="hp-nickname"
                       style={S.input}
                       placeholder="Nickname or name"
                       maxLength={30}
@@ -4519,7 +4532,11 @@ export default function Help() {
                         setProfile((p) => ({ ...p, nickname: e.target.value }))
                       }
                     />
+                    <label htmlFor="hp-contact" style={{ fontSize: "10px", fontWeight: 600, letterSpacing: "0.8px", textTransform: "uppercase", color: "rgba(242,236,220,0.72)" }}>
+                      Contact (phone or Telegram)
+                    </label>
                     <input
+                      id="hp-contact"
                       style={{
                         ...S.input,
                         borderColor: contactError && profile.contact ? "rgba(255,122,107,0.5)" : S.input.border,
@@ -4533,16 +4550,18 @@ export default function Help() {
                         const result = validateContact(val);
                         setContactError(result.valid ? "" : result.error);
                       }}
+                      aria-describedby={contactError && profile.contact ? "hp-contact-error" : undefined}
+                      aria-invalid={Boolean(contactError && profile.contact)}
                     />
                     {contactError && profile.contact && (
-                      <div style={{ fontSize: "10px", color: "#FF7A6B", marginTop: "4px", lineHeight: 1.4 }}>
+                      <div id="hp-contact-error" role="alert" style={{ fontSize: "10px", color: "#FF7A6B", marginTop: "4px", lineHeight: 1.4 }}>
                         {contactError}
                       </div>
                     )}
                     <div
                       style={{
                         fontSize: "9.5px",
-                        color: "rgba(242,236,220,0.18)",
+                        color: "rgba(242,236,220,0.65)",
                         lineHeight: 1.4,
                       }}
                     >
@@ -6238,7 +6257,11 @@ export default function Help() {
                       </div>
                     )}
                   </div>
+                  <label htmlFor="hp-profile-nickname" style={{ display: "block", fontSize: "10px", fontWeight: 600, letterSpacing: "0.8px", textTransform: "uppercase", color: "rgba(242,236,220,0.72)", marginBottom: "5px" }}>
+                    On-chain alias
+                  </label>
                   <input
+                    id="hp-profile-nickname"
                     style={{
                       width: "100%",
                       padding: "8px 10px",
@@ -6260,7 +6283,7 @@ export default function Help() {
                   <div
                     style={{
                       fontSize: "9.5px",
-                      color: "rgba(242,236,220,0.18)",
+                      color: "rgba(242,236,220,0.65)",
                       marginTop: "4px",
                       lineHeight: 1.4,
                     }}
@@ -6280,10 +6303,11 @@ export default function Help() {
                     }}
                   >
                     <div
+                      id="hp-profile-contact-label"
                       style={{
                         fontSize: "11px",
                         fontWeight: 600,
-                        color: "rgba(242,236,220,0.5)",
+                        color: "rgba(242,236,220,0.72)",
                       }}
                     >
                       Contact
@@ -6326,16 +6350,20 @@ export default function Help() {
                       const result = validateContact(val);
                       setContactError(result.valid ? "" : result.error);
                     }}
+                    id="hp-profile-contact"
+                    aria-labelledby="hp-profile-contact-label"
+                    aria-describedby={contactError && profile.contact ? "hp-profile-contact-error" : undefined}
+                    aria-invalid={Boolean(contactError && profile.contact)}
                   />
                   {contactError && profile.contact && (
-                    <div style={{ fontSize: "10px", color: "#FF7A6B", marginTop: "4px", lineHeight: 1.4 }}>
+                    <div id="hp-profile-contact-error" role="alert" style={{ fontSize: "10px", color: "#FF7A6B", marginTop: "4px", lineHeight: 1.4 }}>
                       {contactError}
                     </div>
                   )}
                   <div
                     style={{
                       fontSize: "9.5px",
-                      color: "rgba(242,236,220,0.18)",
+                      color: "rgba(242,236,220,0.65)",
                       marginTop: "4px",
                       lineHeight: 1.4,
                     }}

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -18,6 +18,7 @@ import { useRequestMapState } from "../hooks/useRequestMapState";
 import { useWalletState } from "../hooks/useWalletState";
 import { useClusterer } from "../hooks/useClusterer";
 import { useGeofencing } from "../hooks/useGeofencing";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 import {
   getRequest,
   getActiveRequests,
@@ -476,6 +477,8 @@ function sanitizeTxHash(txHash) {
 }
 
 function ArrivalThanksModal({ open, onClose, requestLabel, txHash }) {
+  const dialogRef = useRef(null);
+  useFocusTrap(open, dialogRef);
   if (!open) return null;
 
   const handleLastAction = (e) => {
@@ -511,6 +514,9 @@ function ArrivalThanksModal({ open, onClose, requestLabel, txHash }) {
       }}
     >
       <div
+        ref={dialogRef}
+        tabIndex={-1}
+        role="document"
         onClick={(e) => e.stopPropagation()}
         style={{
           width: "100%",
@@ -521,6 +527,7 @@ function ArrivalThanksModal({ open, onClose, requestLabel, txHash }) {
           boxShadow: "0 24px 70px rgba(0,0,0,0.58)",
           padding: "24px 22px 20px",
           textAlign: "center",
+          outline: "none",
         }}
       >
         <div
@@ -738,6 +745,7 @@ export function FeedbackModal({ open, onClose, onSubmit }) {
   const [comment, setComment] = useState("");
   const [submitted, setSubmitted] = useState(false);
   const dialogRef = useRef(null);
+  useFocusTrap(open, dialogRef);
 
   useEffect(() => {
     if (open) {
@@ -751,7 +759,7 @@ export function FeedbackModal({ open, onClose, onSubmit }) {
   useEffect(() => {
     if (!open) return undefined;
     const prev = document.activeElement;
-    dialogRef.current?.focus();
+    // initial focus is handled by useFocusTrap; keep prev for restore
     function handleKey(e) {
       if (e.key === "Escape") onClose();
     }
@@ -1097,6 +1105,7 @@ export function HelpOnboardingModal({ open, onClose, onConnectWallet }) {
   const [step, setStep] = useState(0);
   const dialogRef = useRef(null);
   const lastFocusedRef = useRef(null);
+  useFocusTrap(open, dialogRef);
 
   useEffect(() => {
     if (open) setStep(0);
@@ -1109,7 +1118,6 @@ export function HelpOnboardingModal({ open, onClose, onConnectWallet }) {
   useEffect(() => {
     if (!open) return undefined;
     lastFocusedRef.current = document.activeElement;
-    dialogRef.current?.focus();
 
     function handleKeyDown(e) {
       if (e.key === "Escape") {
@@ -2414,6 +2422,8 @@ const ALL_CHARS = [
 ];
 
 function AvatarSelectionModal({ open, onClose, selected, onSelect }) {
+  const dialogRef = useRef(null);
+  useFocusTrap(open, dialogRef);
   if (!open) return null;
 
   return (
@@ -2434,6 +2444,8 @@ function AvatarSelectionModal({ open, onClose, selected, onSelect }) {
       }}
     >
       <div
+        ref={dialogRef}
+        tabIndex={-1}
         onClick={(e) => e.stopPropagation()}
         style={{
           width: "100%",
@@ -2445,6 +2457,7 @@ function AvatarSelectionModal({ open, onClose, selected, onSelect }) {
           boxShadow: "0 24px 70px rgba(0,0,0,0.58)",
           padding: "20px",
           overflow: "auto",
+          outline: "none",
         }}
       >
         <h3
@@ -2702,6 +2715,14 @@ export default function Help() {
   const styleSelectorRef = useRef(null);
   const profileRef = useRef(null);
   const sidebarRef = useRef(null);
+  const cancelDialogRef = useRef(null);
+  const disconnectDialogRef = useRef(null);
+  const resolveDialogRef = useRef(null);
+  const emergencyDialogRef = useRef(null);
+  useFocusTrap(showCancelConfirm !== null, cancelDialogRef);
+  useFocusTrap(showDisconnectConfirm, disconnectDialogRef);
+  useFocusTrap(showResolveConfirm, resolveDialogRef);
+  useFocusTrap(showEmergencyModal, emergencyDialogRef);
   const handleOfferBusy = useRef(false);
   const handleOfferMounted = useRef(true);
   const handleOfferSeq = useRef(0);
@@ -6601,6 +6622,9 @@ export default function Help() {
 
       {showCancelConfirm !== null && (
         <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="cancel-dialog-title"
           onClick={() => setShowCancelConfirm(null)}
           style={{
             position: "fixed",
@@ -6614,6 +6638,9 @@ export default function Help() {
           }}
         >
           <div
+            ref={cancelDialogRef}
+            tabIndex={-1}
+            role="document"
             onClick={(e) => e.stopPropagation()}
             style={{
               background: "#1c3535",
@@ -6623,10 +6650,12 @@ export default function Help() {
               maxWidth: "360px",
               textAlign: "center",
               boxShadow: "0 24px 64px rgba(0,0,0,0.55)",
+              outline: "none",
             }}
           >
             <div style={{ fontSize: "32px", marginBottom: "12px" }}>⚠️</div>
             <h3
+              id="cancel-dialog-title"
               style={{
                 margin: "0 0 6px",
                 fontSize: "18px",
@@ -6640,7 +6669,7 @@ export default function Help() {
               style={{
                 margin: "0 0 20px",
                 fontSize: "13px",
-                color: "rgba(242,236,220,0.5)",
+                color: "rgba(242,236,220,0.72)",
                 lineHeight: 1.5,
               }}
             >
@@ -6687,6 +6716,9 @@ export default function Help() {
 
       {showDisconnectConfirm && (
         <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="disconnect-dialog-title"
           onClick={() => setShowDisconnectConfirm(false)}
           style={{
             position: "fixed",
@@ -6700,6 +6732,9 @@ export default function Help() {
           }}
         >
           <div
+            ref={disconnectDialogRef}
+            tabIndex={-1}
+            role="document"
             onClick={(e) => e.stopPropagation()}
             style={{
               background: "#1c3535",
@@ -6709,10 +6744,12 @@ export default function Help() {
               maxWidth: "360px",
               textAlign: "center",
               boxShadow: "0 24px 64px rgba(0,0,0,0.55)",
+              outline: "none",
             }}
           >
             <div style={{ fontSize: "32px", marginBottom: "12px" }}>⚠️</div>
             <h3
+              id="disconnect-dialog-title"
               style={{
                 margin: "0 0 6px",
                 fontSize: "18px",
@@ -6778,6 +6815,9 @@ export default function Help() {
 
       {showResolveConfirm && (
         <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="resolve-dialog-title"
           onClick={() => setShowResolveConfirm(false)}
           style={{
             position: "fixed",
@@ -6791,6 +6831,9 @@ export default function Help() {
           }}
         >
           <div
+            ref={resolveDialogRef}
+            tabIndex={-1}
+            role="document"
             onClick={(e) => e.stopPropagation()}
             style={{
               background: "#1c3535",
@@ -6800,10 +6843,12 @@ export default function Help() {
               maxWidth: "360px",
               textAlign: "center",
               boxShadow: "0 24px 64px rgba(0,0,0,0.55)",
+              outline: "none",
             }}
           >
             <div style={{ fontSize: "32px", marginBottom: "12px" }}>⚠️</div>
             <h3
+              id="resolve-dialog-title"
               style={{
                 margin: "0 0 6px",
                 fontSize: "18px",
@@ -6817,7 +6862,7 @@ export default function Help() {
               style={{
                 margin: "0 0 20px",
                 fontSize: "13px",
-                color: "rgba(242,236,220,0.5)",
+                color: "rgba(242,236,220,0.72)",
                 lineHeight: 1.5,
               }}
             >
@@ -6878,6 +6923,9 @@ export default function Help() {
 
       {showEmergencyModal && (
         <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="emergency-dialog-title"
           onClick={() => setShowEmergencyModal(false)}
           style={{
             position: "fixed",
@@ -6891,6 +6939,9 @@ export default function Help() {
           }}
         >
           <div
+            ref={emergencyDialogRef}
+            tabIndex={-1}
+            role="document"
             onClick={(e) => e.stopPropagation()}
             style={{
               background: "#1c3535",
@@ -6901,6 +6952,7 @@ export default function Help() {
               maxHeight: "85vh",
               overflowY: "auto",
               boxShadow: "0 24px 64px rgba(0,0,0,0.55)",
+              outline: "none",
             }}
           >
             <div
@@ -6913,6 +6965,7 @@ export default function Help() {
             >
               <div>
                 <h2
+                  id="emergency-dialog-title"
                   style={{
                     margin: 0,
                     fontSize: "22px",
@@ -6927,7 +6980,7 @@ export default function Help() {
                   style={{
                     margin: "6px 0 0",
                     fontSize: "13px",
-                    color: "rgba(242,236,220,0.4)",
+                    color: "rgba(242,236,220,0.72)",
                     lineHeight: 1.4,
                   }}
                 >

--- a/src/pages/VaultDashboard.jsx
+++ b/src/pages/VaultDashboard.jsx
@@ -136,7 +136,7 @@ function CampaignCard({
             style={{
               fontSize: "9px",
               letterSpacing: "1px",
-              color: "rgba(242,236,220,0.35)",
+              color: "rgba(242,236,220,0.72)",
               marginBottom: "4px",
             }}
           >
@@ -158,7 +158,7 @@ function CampaignCard({
             style={{
               fontSize: "9px",
               letterSpacing: "1px",
-              color: "rgba(242,236,220,0.35)",
+              color: "rgba(242,236,220,0.72)",
               marginBottom: "4px",
             }}
           >
@@ -180,7 +180,7 @@ function CampaignCard({
             style={{
               fontSize: "9px",
               letterSpacing: "1px",
-              color: "rgba(242,236,220,0.35)",
+              color: "rgba(242,236,220,0.72)",
               marginBottom: "4px",
             }}
           >
@@ -537,7 +537,7 @@ export default function VaultDashboard() {
                 style={{
                   fontSize: "9px",
                   letterSpacing: "1px",
-                  color: "rgba(242,236,220,0.35)",
+                  color: "rgba(242,236,220,0.72)",
                   marginBottom: "4px",
                 }}
               >
@@ -567,7 +567,7 @@ export default function VaultDashboard() {
                 style={{
                   fontSize: "9px",
                   letterSpacing: "1px",
-                  color: "rgba(242,236,220,0.35)",
+                  color: "rgba(242,236,220,0.72)",
                   marginBottom: "4px",
                 }}
               >

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -141,6 +141,19 @@ body {
   outline: 3px solid #234b4e !important;
 }
 
+/* Visually hidden — accessible labels when design prohibits visible ones */
+.hp-sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
 /* Focus visibility */
 :focus-visible {
   outline: 2px solid var(--color-teal);

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -27,8 +27,8 @@
   --color-border-light: #b9ae9c;
   --color-text: #2a2620;
   --color-text-secondary: #5a554c;
-  --color-text-muted: #7a7264;
-  --color-text-faint: #6b6457;
+  --color-text-muted: #5a554c;
+  --color-text-faint: #655f52;
   --color-cream-text: #f4ecdc;
   --color-footer-text: #cfdcd4;
   --color-footer-dim: #9fb4ab;


### PR DESCRIPTION
All 4 accessibility issues resolved:

Closes #91 Focus Trapping — 5098240

Created src/hooks/useFocusTrap.js:17 — lightweight trap (Tab/Shift+Tab loop, initial focus to first interactive element)
Applied to src/components/ui/Modal.jsx:1 (added dialogRef + useFocusTrap) and src/pages/Help.tsx:480, 742, 1104, 2426 (ArrivalThanksModal, FeedbackModal, HelpOnboardingModal, AvatarSelectionModal) plus inline dialogs src/pages/Help.tsx:2715 (cancelDialogRef/disconnectDialogRef/resolveDialogRef/emergencyDialogRef)

Closes #92 Escape Key — 9466a86

Created src/hooks/useEscapeKey.js:12 — global document keydown listener, closes on Escape, restores focus with queueMicrotask
Enhanced src/hooks/useFocusTrap.js:76 to restore focus on cleanup
Added useEscapeKey to src/pages/Help.tsx:482, 2428 and inline confirms src/pages/Help.tsx:2731 (cancel/disconnect/resolve/emergency)

Closes #90 Proper Labels — fbd3aea

Added src/styles/global.css:144 .hp-sr-only utility
src/pages/Help.tsx:885 (hp-feedback-comment label + aria-label), 4274 (hp-search-location hidden label), 4522/4536 (visible labels hp-nickname/hp-contact + aria-describedby), 6272/6332 (profile hp-profile-nickname/hp-profile-contact)

Closes #89 Low Contrast — 434c3f8

src/pages/Help.tsx:17+ — replaced 51+ rgba(242,236,220,0.18-0.35) → 0.65-0.72
src/components/ui/Input.css:46, 84 — placeholder/hint 0.35/0.38 → 0.72
src/components/layout/Navbar.css:83 — 0.35 → 0.72; src/components/Breadcrumb.jsx:61 — 0.25 → 0.72
src/styles/theme.css:30 — --color-text-muted #7a7264→#5a554c (contrast 3.64→5.67), --color-text-faint #6b6457→#655f52 (4.49→4.86) on #ECE0CC
